### PR TITLE
Backend: bootstrap Spring Boot 3 project

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,35 @@
+name: Backend CI
+
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+  push:
+    branches:
+      - develop
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: backend/pom.xml
+
+      - name: Run tests
+        run: mvn --batch-mode --update-snapshots verify

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,6 @@
+target/
+.idea/
+*.iml
+.classpath
+.project
+.settings/

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.dani811.arhome</groupId>
+    <artifactId>ar-home-backend</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>AR Home Backend</name>
+    <description>Spatial inventory API</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/dani811/arhome/ArHomeApplication.java
+++ b/backend/src/main/java/com/dani811/arhome/ArHomeApplication.java
@@ -1,0 +1,12 @@
+package com.dani811.arhome;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ArHomeApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ArHomeApplication.class, args);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+spring:
+  application:
+    name: ar-home-backend
+
+server:
+  port: ${SERVER_PORT:8080}
+  shutdown: graceful
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true
+
+info:
+  app:
+    name: AR Home Backend
+    version: "@project.version@"

--- a/backend/src/test/java/com/dani811/arhome/ArHomeApplicationTest.java
+++ b/backend/src/test/java/com/dani811/arhome/ArHomeApplicationTest.java
@@ -1,0 +1,12 @@
+package com.dani811.arhome;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ArHomeApplicationTest {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
Closes #4

## Qué cambia

- añade un proyecto Maven con Java 21 y Spring Boot 3;
- incorpora Actuator y configuración de health, liveness y readiness;
- añade la clase principal y un test de carga de contexto;
- incorpora CI con Maven sobre Java 21;
- mantiene fuera dominio, persistencia y mensajería.

## Validación

La rama queda preparada para ejecutar `mvn verify` en GitHub Actions. No se ha añadido lógica de negocio para preservar la atomicidad del cambio.

## Dependencia

Este PR está apilado sobre `agent/bootstrap-spatial-monorepo` y debe integrarse después del PR #3.