### PR TITLE
Tooling: adopt Spec Kit with AR Home roles and overrides

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,55 @@
+# AR Home Engineering Constitution
+
+## 1. Specification is the source of truth
+
+Every product change MUST originate from an approved specification. The implementation, tests, API contracts and documentation MUST remain traceable to the feature spec and plan. Code that changes intended behaviour without updating the specification is non-compliant.
+
+## 2. Atomic delivery
+
+Tasks and pull requests MUST have one primary outcome. Dependencies MUST be explicit. Infrastructure, refactors and product behaviour MUST be separated unless coupling is technically unavoidable and documented in the plan.
+
+## 3. Spatial correctness over visual plausibility
+
+Generated maps, routes, anchors and furniture identities MUST expose confidence and provenance. The system MUST NOT present estimated geometry or recognition as exact. Coordinate systems, units, transforms and algorithm versions MUST be explicit and testable.
+
+## 4. Privacy and local-first capture
+
+Interior imagery, depth, geometry and inventory data are sensitive. Collection MUST be minimal, consent-aware and encrypted in transit. Specs MUST define retention, deletion, access control and whether processing is local or remote. Raw capture data MUST NOT be retained indefinitely by default.
+
+## 5. Contract-first interoperability
+
+Boundaries between mobile capture, backend, spatial workers, frontend and Home Assistant MUST use versioned contracts. Breaking contract changes require migration or explicit version negotiation. Coordinate conventions and object-storage ownership MUST be defined in the contract.
+
+## 6. Testable vertical slices
+
+The preferred delivery unit is an end-to-end vertical slice with observable user value. Each plan MUST define unit, integration and contract tests, plus spatial golden datasets when algorithms are involved. A feature is not complete when it only works on a developer machine.
+
+## 7. Modular monolith before distributed complexity
+
+The Java backend starts as a modular monolith. New deployable services require evidence that isolation, scaling or technology constraints justify the operational cost. Spatial processing workers remain separate because their runtime and compute model differ materially.
+
+## 8. Human validation for uncertain automation
+
+Furniture recognition, room extraction and route generation MUST support manual correction. Automated decisions affecting inventory location MUST retain observations and confidence so a user can understand and override them.
+
+## Quality gates
+
+Before implementation:
+
+- spec has measurable acceptance scenarios;
+- ambiguities affecting data, privacy, geometry or UX are resolved;
+- plan passes architecture and contract review;
+- tasks are atomic and dependency ordered;
+- `speckit-analyze` reports no unresolved critical inconsistency.
+
+Before merge:
+
+- relevant tests pass;
+- spec/plan/tasks reflect the final behaviour;
+- API and spatial contracts are versioned;
+- privacy and security impacts are reviewed;
+- `speckit-converge` has no untracked mandatory work.
+
+## Governance
+
+This constitution overrides convenience and local implementation preferences. Amendments require a dedicated pull request explaining the motivation, affected workflows and migration impact. Feature pull requests MUST NOT silently amend these principles.

--- a/.specify/templates/overrides/plan-template.md
+++ b/.specify/templates/overrides/plan-template.md
@@ -1,0 +1,91 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Spec**: [LINK] | **Date**: [DATE]
+
+## Summary
+
+[Technical approach and boundaries.]
+
+## Constitution check
+
+- Specification is source of truth: [PASS/FAIL + evidence]
+- Atomic delivery: [PASS/FAIL]
+- Spatial correctness/provenance: [PASS/NA]
+- Privacy/local-first: [PASS/NA]
+- Contract-first interoperability: [PASS/NA]
+- Testable vertical slice: [PASS/FAIL]
+- Modular monolith constraint: [PASS/NA]
+- Human correction for uncertainty: [PASS/NA]
+
+Unresolved failures block task generation.
+
+## Technical context
+
+- Modules affected:
+- Runtime/languages:
+- Storage and ownership:
+- External integrations:
+- Device capability requirements:
+- Performance budget:
+
+## Architecture and boundaries
+
+### Components
+
+[Responsibilities and dependency direction.]
+
+### Contracts
+
+- Contract/schema:
+- Versioning strategy:
+- Idempotency:
+- Error model:
+- Coordinate system and units: [or N/A]
+
+### Data model and migrations
+
+[Entities, ownership, migration and deletion impact.]
+
+### Failure and recovery
+
+[Retries, partial upload, tracking loss, processing failure, rollback.]
+
+## Security and privacy
+
+- Threats:
+- Authorization:
+- Sensitive data:
+- Retention/deletion:
+- Logging restrictions:
+
+## Test strategy
+
+- Unit:
+- Integration:
+- Contract:
+- End-to-end:
+- Spatial golden dataset/metrics: [or N/A]
+
+## Role matrix
+
+| Role | Required | Owner | Gate evidence |
+|---|---:|---|---|
+| Product | yes | TBD | acceptance scenarios |
+| Architecture | conditional | TBD | plan/ADR |
+| Backend | conditional | TBD | tests/API contract |
+| Frontend/3D | conditional | TBD | UI/performance evidence |
+| XR Capture | conditional | TBD | device/tracking evidence |
+| Spatial Vision | conditional | TBD | metrics/golden dataset |
+| QA | yes | TBD | traceability matrix |
+| Security/Privacy | conditional | TBD | threat/privacy review |
+
+## Delivery slices
+
+Each slice must be independently demonstrable and map to acceptance scenarios.
+
+1. [Walking skeleton]
+2. [Increment]
+
+## Decisions and ADRs
+
+- [Decision, alternatives, rationale]

--- a/.specify/templates/overrides/spec-template.md
+++ b/.specify/templates/overrides/spec-template.md
@@ -1,0 +1,72 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: [USER DESCRIPTION]
+
+## Problem and outcomes
+
+### Problem statement
+
+[Describe the user problem and why it matters. Do not prescribe implementation.]
+
+### Target users and environments
+
+- User cohorts: [home / warehouse / retail / administrator / operator]
+- Physical environments: [constraints, scale, lighting, connectivity]
+- Supported device classes: [only when behaviour depends on capability]
+
+## User scenarios and acceptance
+
+### User Story 1 — [TITLE] (Priority: P1)
+
+[Independent user journey.]
+
+**Why this priority**: [VALUE]
+
+**Independent test**: [HOW TO VERIFY]
+
+**Acceptance scenarios**:
+
+1. **Given** [STATE], **When** [ACTION], **Then** [OUTCOME]
+2. **Given** [STATE], **When** [FAILURE/EDGE], **Then** [SAFE OUTCOME]
+
+## Spatial and uncertainty requirements
+
+- Coordinate/measurement expectations: [or N/A]
+- Accuracy or confidence visible to the user: [or N/A]
+- Manual correction/override: [or N/A]
+- Tracking-loss behaviour: [or N/A]
+
+## Data and privacy requirements
+
+- Data collected:
+- Data classification:
+- Processing location: [device / local server / cloud]
+- Retention and deletion:
+- Sharing and authorization:
+
+## Functional requirements
+
+- **FR-001**: The system MUST ...
+
+## Non-functional requirements
+
+- **NFR-001 Performance**: ...
+- **NFR-002 Reliability**: ...
+- **NFR-003 Accessibility**: ...
+- **NFR-004 Privacy/Security**: ...
+
+## Out of scope
+
+- [Explicit exclusions]
+
+## Success criteria
+
+- **SC-001**: [Measurable, technology-independent outcome]
+
+## Assumptions and open questions
+
+- Assumption:
+- Open question requiring `/speckit.clarify`:

--- a/.specify/templates/overrides/tasks-template.md
+++ b/.specify/templates/overrides/tasks-template.md
@@ -1,0 +1,62 @@
+# Tasks: [FEATURE]
+
+**Spec**: [LINK]  
+**Plan**: [LINK]
+
+## Task rules
+
+Every task MUST:
+
+- use an ID `T###`;
+- have one primary outcome;
+- identify module/files affected;
+- state dependencies;
+- map to one or more requirements or acceptance scenarios;
+- include verification evidence;
+- be suitable for one focused pull request unless marked `[groupable]`.
+
+Format:
+
+```text
+- [ ] T001 [P?] [US?] Outcome — module/path
+      Depends on: none | T###
+      Traces to: FR-###, SC-###, Scenario #
+      Verify: exact test, command or observable behaviour
+      Roles: required reviewers/gates
+```
+
+## Phase 1 — Walking skeleton
+
+- [ ] T001 [US1] [Atomic outcome] — [path]
+      Depends on: none
+      Traces to: [requirements]
+      Verify: [evidence]
+      Roles: Product, QA, [conditional roles]
+
+## Phase 2 — Independent user story increments
+
+### User Story 1
+
+- [ ] T002 [US1] [Atomic outcome] — [path]
+      Depends on: T001
+      Traces to: [requirements]
+      Verify: [evidence]
+      Roles: [roles]
+
+## Phase 3 — Hardening
+
+- [ ] T900 [Cross-cutting but single outcome] — [path]
+      Depends on: [tasks]
+      Traces to: [NFR]
+      Verify: [evidence]
+      Roles: QA, Security/Privacy
+
+## Traceability check
+
+| Requirement/scenario | Covered by tasks | Verification |
+|---|---|---|
+| FR-001 | T### | [test/evidence] |
+
+## Parallelization notes
+
+Only tasks marked `[P]` may run in parallel. They MUST not modify the same files, schema or contract and MUST not depend on unmerged behaviour.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AR Home Roles and Review Gates
+
+These roles are responsibilities, not necessarily separate people or agents. One contributor may hold several roles, but each required gate must be addressed explicitly.
+
+## Product Owner
+
+Owns problem framing, user scenarios, scope and acceptance outcomes.
+
+Required in: `spec.md`.
+
+Rejects when:
+- the feature describes technology instead of user value;
+- success cannot be observed or measured;
+- edge cases for homes, warehouses or shops are ignored.
+
+## Solution Architect
+
+Owns module boundaries, contracts, data ownership, deployment topology and ADRs.
+
+Required in: `plan.md`.
+
+Rejects when:
+- a new service lacks operational justification;
+- versioning, migration or failure behaviour is absent;
+- frontend, backend and spatial worker responsibilities overlap ambiguously.
+
+## Backend Engineer
+
+Owns Java/Spring modules, persistence, API behaviour, idempotency and asynchronous orchestration.
+
+Required when: `backend/**`, database, queue or object-storage APIs change.
+
+Gate:
+- transactional boundaries documented;
+- API errors structured;
+- idempotency and concurrency considered;
+- unit and integration tests included.
+
+## Frontend and 3D Engineer
+
+Owns Angular architecture, Three.js scene lifecycle, 2D/3D synchronization, accessibility and performance.
+
+Required when: `frontend/**` or visual navigation changes.
+
+Gate:
+- state ownership is explicit;
+- WebGL resources are disposed;
+- large models use progressive loading;
+- non-3D fallback and keyboard interaction are considered.
+
+## XR Capture Engineer
+
+Owns ARCore, ARKit, RoomPlan, WebXR fallback, sensors, coordinate transforms and offline upload.
+
+Required when: `capture-mobile/**` or capture contracts change.
+
+Gate:
+- device capability matrix documented;
+- tracking loss and recovery specified;
+- timestamps and coordinate frames are unambiguous;
+- battery, storage and offline behaviour are covered.
+
+## Spatial Vision Engineer
+
+Owns keyframes, pose graph, reconstruction, segmentation, multiview fusion, confidence and algorithm provenance.
+
+Required when: `spatial-processing/**`, geometry or recognition changes.
+
+Gate:
+- input/output datasets versioned;
+- metrics and acceptance thresholds defined;
+- confidence and failure modes exposed;
+- golden dataset or reproducible evaluation included.
+
+## QA and Test Engineer
+
+Owns acceptance traceability, test pyramid, fixtures, contract tests and end-to-end validation.
+
+Required for every feature.
+
+Gate:
+- each acceptance scenario maps to evidence;
+- failure and retry paths are tested;
+- tests are deterministic;
+- flaky tests block completion.
+
+## Security and Privacy Reviewer
+
+Owns threat modelling, authorization, secrets, retention and sensitive indoor data handling.
+
+Required when capture data, identity, sharing, cloud processing or external integrations change.
+
+Gate:
+- data classification and retention defined;
+- least privilege applied;
+- deletion and export paths specified;
+- logs exclude sensitive imagery, tokens and precise location data.
+
+## Role assignment in a feature
+
+Every `plan.md` must contain a role matrix:
+
+| Role | Required | Owner | Gate evidence |
+|---|---:|---|---|
+| Product | yes | TBD | acceptance scenarios |
+| Architecture | conditional | TBD | plan/ADR |
+| Backend | conditional | TBD | tests/API contract |
+| Frontend/3D | conditional | TBD | UI/performance evidence |
+| XR Capture | conditional | TBD | device/tracking evidence |
+| Spatial Vision | conditional | TBD | metrics/golden dataset |
+| QA | yes | TBD | traceability matrix |
+| Security/Privacy | conditional | TBD | threat/privacy review |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Consulta [`docs/architecture.md`](docs/architecture.md) para el diseño del sist
 | Procesamiento | Python 3.12, OpenCV, Open3D, PyTorch |
 | Integraciones | REST, WebSocket, MQTT, Home Assistant |
 
+## Desarrollo dirigido por especificaciones
+
+AR Home utiliza GitHub Spec Kit con versión fijada. La constitución del proyecto, los overrides y los roles de revisión viven en:
+
+- [`.specify/memory/constitution.md`](.specify/memory/constitution.md)
+- [`.specify/templates/overrides/`](.specify/templates/overrides/)
+- [`AGENTS.md`](AGENTS.md)
+- [`docs/spec-kit.md`](docs/spec-kit.md)
+
+Instalación reproducible:
+
+```bash
+bash scripts/setup-speckit.sh
+```
+
+Cada feature sigue el flujo: especificar, aclarar, planificar, generar tareas atómicas, analizar consistencia, implementar y converger.
+
 ## Estado
 
 El repositorio está en fase de bootstrap arquitectónico. La prioridad es cerrar el contrato de captura y construir una primera vertical funcional:

--- a/docs/spec-kit.md
+++ b/docs/spec-kit.md
@@ -1,0 +1,52 @@
+# Spec Kit en AR Home
+
+## Versión fijada
+
+AR Home utiliza GitHub Spec Kit `v0.12.11`.
+
+## Instalación local
+
+Requisitos: Git, Python 3.11+ y `uv`.
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.12.11
+specify self check
+specify init --here --force --integration codex --integration-options="--skills"
+```
+
+La inicialización debe ejecutarse desde la raíz del repositorio. Antes de aceptar cambios generados por una actualización de Spec Kit, se revisarán por separado de cualquier feature.
+
+## Flujo obligatorio por feature
+
+1. `speckit-constitution`: modificar principios solo cuando cambie la gobernanza.
+2. `speckit-specify`: describir problema, usuarios, escenarios y resultados, sin diseñar la solución.
+3. `speckit-clarify`: resolver ambigüedades que afecten alcance, seguridad, datos o UX.
+4. `speckit-plan`: fijar arquitectura, contratos, decisiones y estrategia de pruebas.
+5. `speckit-tasks`: producir tareas atómicas, ordenadas y verificables.
+6. `speckit-analyze`: comprobar cobertura y consistencia antes de implementar.
+7. `speckit-taskstoissues`: convertir tareas aprobadas en GitHub Issues.
+8. `speckit-implement`: implementar una tarea o conjunto explícitamente acotado.
+9. `speckit-converge`: detectar drift entre spec, plan, tareas y código.
+
+## Reglas de atomicidad
+
+Una tarea:
+
+- tiene un único resultado observable;
+- puede revisarse de forma independiente;
+- enumera archivos o módulos afectados;
+- incluye prueba o evidencia verificable;
+- declara dependencias mediante IDs de tarea o issues;
+- no mezcla refactor, infraestructura y feature salvo necesidad técnica demostrada;
+- no debe exceder un PR razonablemente revisable.
+
+## Estrategia de personalización
+
+- `.specify/memory/constitution.md`: principios no negociables.
+- `.specify/templates/overrides/`: cambios locales sobre plantillas base.
+- `AGENTS.md`: responsabilidades y gates por rol.
+- Presets: solo cuando una personalización sea reutilizable y estable.
+- Extensions: solo para nuevas capacidades, tras auditoría de código y versión fijada.
+- Bundles: se crearán cuando los roles estén validados en varias features.
+
+Los overrides locales son deliberadamente pequeños. No copiamos todas las plantillas de Spec Kit: solo imponemos requisitos propios del dominio espacial y del monorepo.

--- a/scripts/setup-speckit.sh
+++ b/scripts/setup-speckit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPEC_KIT_VERSION="v0.12.11"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Error: uv is required. Install it from https://docs.astral.sh/uv/" >&2
+  exit 1
+fi
+
+uv tool install specify-cli --force \
+  --from "git+https://github.com/github/spec-kit.git@${SPEC_KIT_VERSION}"
+
+specify self check
+specify init --here --force \
+  --integration codex \
+  --integration-options="--skills"
+
+echo "Spec Kit ${SPEC_KIT_VERSION} initialized for Codex skills mode."
+echo "Review generated changes before committing; tooling upgrades must use a dedicated PR."


### PR DESCRIPTION
Closes #10

## Qué cambia

- fija GitHub Spec Kit en `v0.12.11` mediante un script reproducible;
- documenta el flujo obligatorio de desarrollo dirigido por especificaciones;
- añade la constitución de ingeniería de AR Home;
- incorpora overrides locales para `spec`, `plan` y `tasks`;
- define roles y gates de producto, arquitectura, backend, frontend/3D, XR, visión espacial, QA y seguridad/privacidad;
- exige tareas atómicas, trazabilidad y verificación explícita.

## Decisiones

- usamos Codex en skills mode;
- no instalamos extensiones comunitarias todavía;
- los overrides locales se mantienen pequeños y específicos del dominio;
- los upgrades de Spec Kit deben ir en PRs separados de las features.

## Validación

- la versión está fijada y la instalación es reproducible mediante `bash scripts/setup-speckit.sh`;
- la estructura respeta la prioridad de overrides locales de Spec Kit;
- cada plan debe declarar roles y evidencia de gates;
- cada tarea debe mapear requisitos, dependencias y verificación.

## Dependencia

Este PR está apilado sobre el PR #3 y no modifica código de producto.