### PR TITLE
Engineering: adopt Spec Kit governance and role overrides

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Spec Kit traceability
+
+- Spec: `specs/.../spec.md`
+- Plan: `specs/.../plan.md`
+- Tasks: `specs/.../tasks.md`
+- Issue:
+- ADR, if required:
+- Accountable roles:
+
+## Scope
+
+Describe the single concern changed by this PR and its explicit non-goals.
+
+## Acceptance evidence
+
+- [ ] Acceptance criteria are satisfied.
+- [ ] Tests cover new or changed behavior.
+- [ ] CI is green.
+- [ ] Contracts and migrations are versioned and documented.
+- [ ] Security and privacy impacts were reviewed.
+- [ ] Logs, metrics and failure diagnostics are adequate.
+- [ ] Documentation and runbooks are updated where applicable.
+- [ ] Implementation matches the constitution, spec, plan and tasks.
+- [ ] Remaining gaps are tracked as explicit issues/tasks.
+
+## Atomicity
+
+- Net changed lines:
+- [ ] The PR is within the 300-line default limit, or a justification is provided below.
+
+Justification:
+
+## Validation
+
+List exact commands, fixtures, devices and tolerances used.

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,37 @@
+# AR Home Constitution
+
+## 1. Spec before code
+Every feature starts from an approved specification that states user value, scope, non-goals, acceptance criteria and measurable outcomes. Implementation must not begin while material ambiguities remain.
+
+## 2. Atomic delivery
+Each task and pull request must represent one independently reviewable change. The default limit is 300 net changed lines; larger changes require an explicit justification in the PR. Infrastructure, domain changes and UI work must not be mixed without necessity.
+
+## 3. Contract-first boundaries
+Public APIs, events and spatial payloads are versioned before implementation. Breaking changes require a migration path and an architecture decision record. Coordinate systems, units, timestamps and identifiers must be explicit.
+
+## 4. Testable behavior
+Acceptance criteria must be executable or objectively verifiable. Backend endpoints require automated tests. Spatial algorithms require deterministic fixtures and tolerance-based assertions. Bugs require a regression test whenever feasible.
+
+## 5. Privacy and security by design
+Indoor imagery, geometry, device poses and inventory data are sensitive. Specifications and plans must address data minimization, retention, encryption, authorization, deletion and offline behavior. Raw captures are never exposed publicly by default.
+
+## 6. Observable and reversible systems
+Long-running capture and processing work must expose status, failure reasons and correlation identifiers. Migrations and deployments need rollback strategies. Jobs must be idempotent and safe to retry.
+
+## 7. Spatial correctness over visual plausibility
+The system must distinguish measured, inferred and manually confirmed spatial data. Confidence, provenance and algorithm version must be stored. A visually convincing result is not accepted if its coordinate semantics are undefined.
+
+## 8. Modular monolith first
+The backend starts as a modular monolith. Services are extracted only with evidence of an operational or scaling need. Python/C++ spatial workers remain separate because their runtime and dependency profile are materially different.
+
+## 9. Human validation
+Automatic reconstruction and recognition must support review and correction. The system must preserve manual overrides and must not silently replace user-confirmed spatial identities.
+
+## 10. Definition of done
+A task is done only when code, tests, documentation, contracts, migrations, security considerations and operational impact are complete as applicable; CI is green; and the implementation still matches spec, plan and tasks.
+
+## Governance
+- This constitution overrides feature-level convenience.
+- Changes require a dedicated PR and rationale.
+- Architectural changes require an ADR in `docs/adr/`.
+- Spec Kit artifacts in `specs/` are product records and evolve with intended behavior.

--- a/.specify/templates/overrides/plan-template.md
+++ b/.specify/templates/overrides/plan-template.md
@@ -1,0 +1,52 @@
+# Implementation Plan: [FEATURE]
+
+**Spec**: [PATH]  
+**Branch**: [BRANCH]  
+**Owners / roles**: [ROLES]
+
+## Constitution check
+
+Confirm compliance with every applicable principle in `.specify/memory/constitution.md`. Any exception must be explicit and approved before implementation.
+
+## Technical context
+
+- Runtime and versions:
+- Modules affected:
+- Persistence and migrations:
+- External services:
+- Device/platform constraints:
+- Performance budgets:
+
+## Architecture and boundaries
+
+Describe module ownership, data flow and why the design belongs in existing boundaries. Link required ADRs.
+
+## Contracts
+
+List APIs, events and schemas. Define versions, units, coordinate frames, timestamps, idempotency keys and compatibility strategy.
+
+## Security and privacy design
+
+Cover threat model, authorization, sensitive-data flow, encryption, retention, deletion, logging redaction and consent.
+
+## Observability and operations
+
+Define logs, metrics, traces, correlation IDs, job states, failure reasons, retries, rollback and support diagnostics.
+
+## Test strategy
+
+- Unit:
+- Integration:
+- Contract:
+- End-to-end:
+- Spatial fixtures and tolerances:
+- Device/browser matrix:
+
+## Delivery slices
+
+Break implementation into independently reviewable PRs. Default maximum: 300 net changed lines per PR unless justified.
+
+## Risks and decisions
+
+| Risk / decision | Mitigation / outcome | Owner |
+|---|---|---|

--- a/.specify/templates/overrides/spec-template.md
+++ b/.specify/templates/overrides/spec-template.md
@@ -1,0 +1,60 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Epic / Project**: [LINKS]  
+**Accountable roles**: [ROLES]
+
+## Problem and user value
+
+Describe the user problem, affected users and measurable value. Do not prescribe implementation.
+
+## User scenarios and acceptance
+
+### Scenario 1 — [TITLE]
+
+**Given** [context]  
+**When** [action]  
+**Then** [observable outcome]
+
+## Functional requirements
+
+- **FR-001**: The system MUST ...
+
+## Non-goals
+
+- Explicitly list behavior excluded from this feature.
+
+## Domain and contract impact
+
+- Entities and invariants affected.
+- API/event/schema changes.
+- Coordinate system, units, timestamps and identifiers when spatial data is involved.
+- Backward compatibility and migration expectations.
+
+## Privacy and security
+
+- Data classification and minimization.
+- Authorization and exposure boundaries.
+- Retention, deletion and encryption.
+- Camera/location/indoor imagery consent implications.
+
+## Quality attributes
+
+- Performance and resource budgets.
+- Availability, offline and retry behavior.
+- Accessibility and supported devices.
+- Observability and failure diagnostics.
+
+## Spatial evidence and confidence
+
+When applicable, state which data is measured, inferred or manually confirmed; required confidence/provenance; and acceptable tolerances.
+
+## Success criteria
+
+- **SC-001**: [Measurable, technology-independent outcome]
+
+## Open questions
+
+- [QUESTION requiring clarification before planning]

--- a/.specify/templates/overrides/tasks-template.md
+++ b/.specify/templates/overrides/tasks-template.md
@@ -1,0 +1,39 @@
+# Tasks: [FEATURE]
+
+**Spec**: [PATH]  
+**Plan**: [PATH]
+
+## Rules
+
+- Every task must be independently verifiable.
+- Keep one concern per task and one primary module per PR.
+- Mark dependencies explicitly.
+- Put contract and migration work before consumers.
+- Put tests beside the behavior they validate, not in a final cleanup bucket.
+- Include privacy, security, observability and documentation tasks when applicable.
+
+## Phase 1 — Contracts and foundations
+
+- [ ] T001 [P?] [module] Define or update versioned contract and compatibility notes.
+- [ ] T002 [module] Add required migration or configuration.
+
+## Phase 2 — Behavior
+
+- [ ] T003 [module] Implement one domain/application behavior.
+- [ ] T004 [module] Add unit and integration tests for T003.
+
+## Phase 3 — Integration
+
+- [ ] T005 [module] Connect producer and consumer through the approved contract.
+- [ ] T006 [module] Add contract/end-to-end verification.
+
+## Phase 4 — Operational readiness
+
+- [ ] T007 Add logs, metrics, correlation and actionable failure reasons.
+- [ ] T008 Verify authorization, sensitive-data handling, retention and deletion.
+- [ ] T009 Update docs, ADRs and runbooks.
+
+## Phase 5 — Convergence
+
+- [ ] T010 Run consistency analysis against spec, plan and constitution.
+- [ ] T011 Record remaining gaps as new atomic tasks; do not hide them in the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AR Home agent instructions
+
+## Mandatory workflow
+
+For feature work, follow Spec Kit in this order: constitution, specify, clarify, plan, tasks, analyze, implement, converge.
+
+Do not implement a feature without approved `spec.md`, `plan.md` and `tasks.md` artifacts unless the change is a narrowly scoped emergency fix. Emergency fixes still require a regression test and follow-up spec reconciliation.
+
+## Operating rules
+
+- Read `.specify/memory/constitution.md` before planning or coding.
+- Select accountable roles from `docs/engineering/roles.md` based on impact.
+- Keep pull requests atomic; target no more than 300 net changed lines unless justified.
+- Version API, event and spatial schemas before implementing consumers.
+- Never leave coordinate systems, units, timestamps or spatial provenance implicit.
+- Treat indoor imagery, geometry, poses and inventory as sensitive data.
+- Add tests alongside behavior.
+- Record cross-module architectural decisions in `docs/adr/`.
+- Preserve manual spatial corrections and user-confirmed identities.
+- Do not install community Spec Kit components without source review.
+
+## Module ownership
+
+- `backend/`: Backend Engineer; Chief Architect for boundary changes.
+- `frontend/`: Frontend and 3D Engineer.
+- `capture-mobile/`: XR Capture Engineer and Security/Privacy Reviewer.
+- `spatial-processing/`: Spatial AI Engineer.
+- `infrastructure/`: Platform Engineer and Security/Privacy Reviewer.
+- `contracts/`: Chief Architect plus every affected producer/consumer.
+
+## Completion gate
+
+Before marking a task complete, verify implementation against the constitution, feature spec, plan, tasks and acceptance criteria. Record discovered gaps as explicit tasks.

--- a/docs/engineering/roles.md
+++ b/docs/engineering/roles.md
@@ -1,0 +1,41 @@
+# Engineering roles
+
+Roles are review perspectives, not job titles. One person may perform several roles, but every feature must name the accountable roles in its plan.
+
+## Product Owner
+Owns user value, scope, non-goals, acceptance criteria and prioritization. Rejects technically elegant work that does not solve the stated problem.
+
+## Chief Architect
+Owns system boundaries, ADRs, cross-module contracts and technical risk. Reviews any change affecting more than one bounded context or runtime.
+
+## Backend Engineer
+Owns Spring Boot modules, persistence, APIs, transactions, idempotency and domain invariants.
+
+## Frontend and 3D Engineer
+Owns Angular architecture, Three.js scenes, accessibility, performance budgets and state synchronization between 2D, 3D and photographic routes.
+
+## XR Capture Engineer
+Owns ARCore, ARKit, RoomPlan, WebXR fallback, camera intrinsics, poses, IMU, depth, tracking quality and offline upload behavior.
+
+## Spatial AI Engineer
+Owns keyframe selection, pose optimization, reconstruction, semantic extraction, furniture recognition, confidence and algorithm reproducibility.
+
+## Platform Engineer
+Owns Docker, CI/CD, environments, secrets, observability, backups, queues and object storage.
+
+## QA Engineer
+Owns acceptance traceability, test strategy, regression coverage, fixtures, device matrix and non-functional validation.
+
+## Security and Privacy Reviewer
+Owns threat modelling, authorization, encryption, retention, deletion, consent, GDPR impact and safe handling of indoor imagery and geometry.
+
+## Required review matrix
+
+| Change | Required roles |
+|---|---|
+| API or domain | Product Owner, Backend, QA |
+| Cross-module contract | Chief Architect, affected engineers, QA |
+| Mobile capture | XR Capture, Security/Privacy, QA |
+| Spatial processing | Spatial AI, Chief Architect, QA |
+| 2D/3D viewer | Frontend/3D, Product Owner, QA |
+| Infrastructure/security | Platform, Security/Privacy, Chief Architect |

--- a/docs/engineering/spec-kit.md
+++ b/docs/engineering/spec-kit.md
@@ -1,0 +1,55 @@
+# Spec Kit workflow
+
+AR Home uses Spec Kit as the mandatory feature-development workflow.
+
+## Install and initialize
+
+```bash
+./scripts/setup-spec-kit.sh
+```
+
+The script pins Spec Kit to `v0.12.11` and initializes the current repository. Set `SPEC_KIT_INTEGRATION` to use another supported integration.
+
+## Required sequence
+
+1. `speckit.constitution` — update governing principles only in a dedicated governance change.
+2. `speckit.specify` — define problem, user value, scope and measurable acceptance.
+3. `speckit.clarify` — resolve material ambiguity before technical planning.
+4. `speckit.plan` — define architecture, contracts, security, operations and test strategy.
+5. `speckit.tasks` — produce atomic, dependency-ordered tasks.
+6. `speckit.analyze` — check consistency and coverage before implementation.
+7. `speckit.taskstoissues` — create traceable GitHub issues when appropriate.
+8. `speckit.implement` — implement only approved tasks.
+9. `speckit.converge` — compare code with artifacts and append remaining work.
+
+Codex skills mode exposes the same capabilities as `$speckit-*` skills rather than slash commands.
+
+## Artifact layout
+
+```text
+.specify/
+├── memory/constitution.md
+└── templates/overrides/
+    ├── spec-template.md
+    ├── plan-template.md
+    └── tasks-template.md
+specs/
+└── NNN-feature-name/
+    ├── spec.md
+    ├── plan.md
+    ├── tasks.md
+    ├── research.md
+    ├── data-model.md
+    └── contracts/
+```
+
+## Role selection
+
+The feature plan names accountable review roles from `docs/engineering/roles.md`. Roles are selected by impact, not by repository folder alone.
+
+## Change policy
+
+- Spec Kit tooling upgrades are separate from product-spec changes.
+- Community extensions, presets and bundles require source review and a dedicated PR.
+- Project-local overrides are the authoritative AR Home customization layer.
+- Feature implementation may not silently modify its approved specification.

--- a/scripts/setup-spec-kit.sh
+++ b/scripts/setup-spec-kit.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPEC_KIT_VERSION="v0.12.11"
+INTEGRATION="${SPEC_KIT_INTEGRATION:-codex}"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required. Install it from https://docs.astral.sh/uv/ and rerun." >&2
+  exit 1
+fi
+
+uv tool install specify-cli --force \
+  --from "git+https://github.com/github/spec-kit.git@${SPEC_KIT_VERSION}"
+
+args=(init --here --force --integration "${INTEGRATION}")
+if [[ "${INTEGRATION}" == "codex" ]]; then
+  args+=(--integration-options="--skills")
+fi
+
+specify "${args[@]}"
+specify self check
+
+echo "Spec Kit ${SPEC_KIT_VERSION} initialized for ${INTEGRATION}."


### PR DESCRIPTION
Closes #13

## Qué cambia

- fija Spec Kit `v0.12.11` mediante un script reproducible;
- añade la constitución de ingeniería de AR Home;
- define roles técnicos y matriz de revisión;
- incorpora overrides locales para `spec`, `plan` y `tasks`;
- documenta el flujo obligatorio de Spec Kit;
- añade instrucciones operativas para agentes;
- incorpora una plantilla de PR con trazabilidad y gates de calidad.

## Por qué

AR Home combina backend, XR, visión espacial, datos sensibles e infraestructura. Sin una disciplina común, las decisiones y contratos se fragmentarían rápidamente. Este cambio establece un proceso verificable antes de continuar con features.

## Validación

- los overrides están en la ruta de máxima prioridad de Spec Kit: `.specify/templates/overrides/`;
- la instalación está fijada a una versión concreta;
- no se han instalado extensiones comunitarias;
- no se ha modificado código de producto.

## Uso

```bash
./scripts/setup-spec-kit.sh
```

Después, toda feature sigue: `constitution → specify → clarify → plan → tasks → analyze → implement → converge`.

## Dependencia

Este PR está apilado sobre `agent/bootstrap-spatial-monorepo` y debe integrarse después del PR #3.