### PR TITLE
feat: add Angular furniture box editor

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,30 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches: [develop]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm install --no-audit --no-fund
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build:ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Java
+backend/target/
+
+# Angular / Node
+frontend/node_modules/
+frontend/dist/
+frontend/.angular/
+
+# IDE and OS
+.idea/
+.vscode/
+.DS_Store
+*.iml

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Inventario espacial para vivienda con posicionamiento 3D, guiado AR e integración posterior con Home Assistant.
 
-La rama `develop` contiene ahora el primer vertical slice ejecutable del núcleo espacial. La identidad de un mueble **no depende de que un modelo visual lo clasifique perfectamente**: el alta comienza con una caja 3D orientada confirmada por el usuario y la relocalización combina geometría, posición, categoría y evidencia visual.
+La identidad de un mueble **no depende de que un modelo visual lo clasifique perfectamente**: el alta comienza con una caja 3D orientada confirmada por el usuario y la relocalización combina geometría, posición, categoría y evidencia visual.
 
 ## Estado actual
+
+### Backend espacial
 
 Implementado en `backend/`:
 
@@ -16,11 +18,23 @@ Implementado en `backend/`:
 - Posición de objetos relativa al mueble o compartimento.
 - Resolución de pose mundial mediante composición de transformaciones.
 - Ranking de relocalización de muebles conocidos.
-- Validación de consistencia entre muebles, compartimentos y objetos.
-- Pruebas unitarias de matemáticas 3D y lógica espacial.
-- CI de Maven mediante GitHub Actions.
+- Validación de consistencia y pruebas de matemáticas 3D.
 
 Consulta [`docs/spatial-model.md`](docs/spatial-model.md) para las decisiones de dominio.
+
+### Editor Angular + Three.js
+
+Implementado en `frontend/`:
+
+- Angular standalone con TypeScript estricto.
+- Visor Three.js responsive.
+- Caja 3D orientada con modos mover, girar y escalar.
+- `OrbitControls` y `TransformControls` con snaps de 5 cm y 5 grados.
+- Edición numérica de posición, dimensiones y giro vertical.
+- Conversión directa a `Transform3D` y `Bounds3D` del backend.
+- Creación de espacios y registro de muebles mediante la API real.
+- Liberación explícita de controles y recursos WebGL.
+- Build de producción validado mediante GitHub Actions.
 
 ## Jerarquía espacial
 
@@ -37,6 +51,8 @@ Cada nivel almacena una transformación local con traslación en metros y rotaci
 
 ## Ejecución local
 
+### Backend y PostgreSQL
+
 Requisitos: Docker y Docker Compose.
 
 ```bash
@@ -47,12 +63,17 @@ docker compose up
 - Health: `http://localhost:8080/actuator/health`
 - PostgreSQL: `localhost:5432`
 
-También puede ejecutarse únicamente el backend con Java 21 y Maven:
+### Editor web
+
+Requisito: Node.js 22.
 
 ```bash
-cd backend
-mvn spring-boot:run
+cd frontend
+npm install
+npm start
 ```
+
+El proxy de desarrollo reenvía `/api` a `http://localhost:8080`. Abre `http://localhost:4200`.
 
 ## API espacial inicial
 
@@ -73,26 +94,24 @@ GET  /api/v1/spatial/items/{itemId}/world-pose
   "name": "Armario dormitorio",
   "category": "WARDROBE",
   "spaceTransform": {
-    "translation": { "x": 1.2, "y": 0.0, "z": 2.8 },
+    "translation": { "x": 1.2, "y": 1.2, "z": 2.8 },
     "rotation": { "x": 0.0, "y": 0.0, "z": 0.0, "w": 1.0 }
   },
   "bounds": { "width": 2.0, "height": 2.4, "depth": 0.6 },
   "recognitionMode": "MANUAL_BOUNDING_BOX",
-  "confidence": 1.0
+  "confidence": 1.0,
+  "visualDescriptor": null
 }
 ```
 
-### Relocalización
-
-El cliente AR puede enviar una pose aproximada, dimensiones observadas y similitudes visuales calculadas localmente. El backend devuelve candidatos con puntuaciones desglosadas, evitando una decisión opaca e irreversible.
-
 ## Próximos incrementos
 
-1. Cliente Angular/Three.js para dibujar y ajustar la caja orientada del mueble.
-2. Captura WebXR/ARCore y persistencia de observaciones visuales.
-3. Relocalización entre sesiones y calibración de espacios.
-4. Adaptador con Homestead Inventory y Home Assistant.
-5. Navegación AR hasta el compartimento y el objeto.
+1. Captura móvil con `getUserMedia` y superposición del editor sobre la cámara.
+2. WebXR/ARCore para obtener pose y hit-test en dispositivos compatibles.
+3. Persistencia de observaciones visuales y relocalización entre sesiones.
+4. Editor visual de cajones, baldas y otros compartimentos.
+5. Adaptador con Homestead Inventory y Home Assistant.
+6. Navegación AR hasta el compartimento y el objeto.
 
 ## Licencia
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -13,6 +13,7 @@
           "builder": "@angular/build:application",
           "options": {
             "browser": "src/main.ts",
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "css",
             "assets": [],

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "ar-home-frontend": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "arh",
+      "architect": {
+        "build": {
+          "builder": "@angular/build:application",
+          "options": {
+            "browser": "src/main.ts",
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "css",
+            "assets": [],
+            "styles": ["src/styles.css"],
+            "outputPath": "dist/ar-home-frontend"
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "900kB",
+                  "maximumError": "1.2MB"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular/build:dev-server",
+          "configurations": {
+            "production": {
+              "buildTarget": "ar-home-frontend:build:production"
+            },
+            "development": {
+              "buildTarget": "ar-home-frontend:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@angular/cli": "^20.2.0",
     "@angular/compiler-cli": "^20.2.0",
     "@types/three": "^0.180.0",
+    "@webgpu/types": "^0.1.64",
     "typescript": "~5.9.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ar-home-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "ng serve --proxy-config proxy.conf.json",
+    "build": "ng build",
+    "build:ci": "ng build --configuration production"
+  },
+  "dependencies": {
+    "@angular/common": "^20.2.0",
+    "@angular/compiler": "^20.2.0",
+    "@angular/core": "^20.2.0",
+    "@angular/forms": "^20.2.0",
+    "@angular/platform-browser": "^20.2.0",
+    "rxjs": "^7.8.2",
+    "three": "^0.180.0",
+    "tslib": "^2.8.1",
+    "zone.js": "^0.15.1"
+  },
+  "devDependencies": {
+    "@angular/build": "^20.2.0",
+    "@angular/cli": "^20.2.0",
+    "@angular/compiler-cli": "^20.2.0",
+    "@types/three": "^0.180.0",
+    "typescript": "~5.9.2"
+  }
+}

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,0 +1,268 @@
+:host {
+  display: block;
+}
+
+.page-shell {
+  width: min(92rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 3rem 0 5rem;
+}
+
+.hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 2.5rem;
+}
+
+.hero h1 {
+  max-width: 58rem;
+  margin: 0.45rem 0 0.8rem;
+  font-size: clamp(2.1rem, 5vw, 4.4rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.hero-copy {
+  max-width: 52rem;
+  margin: 0;
+  color: #9cafc5;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #42ddff;
+  font-size: 0.72rem;
+  font-weight: 750;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 0.55rem;
+  border: 1px solid rgba(80, 224, 255, 0.2);
+  border-radius: 999px;
+  padding: 0.65rem 0.9rem;
+  background: rgba(9, 24, 40, 0.72);
+  color: #a7c3da;
+  font-size: 0.78rem;
+}
+
+.status-badge span {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #4dffa7;
+  box-shadow: 0 0 1rem rgba(77, 255, 167, 0.75);
+}
+
+.workflow-card,
+.payload-card {
+  border: 1px solid rgba(126, 238, 255, 0.15);
+  border-radius: 1.2rem;
+  background: rgba(8, 19, 33, 0.78);
+  box-shadow: 0 1.2rem 3rem rgba(0, 0, 0, 0.17);
+}
+
+.workflow-card {
+  padding: 1.4rem;
+}
+
+.step-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  margin-bottom: 1.2rem;
+}
+
+.step-heading > span {
+  display: grid;
+  width: 2.2rem;
+  height: 2.2rem;
+  place-items: center;
+  flex: 0 0 auto;
+  border: 1px solid rgba(0, 212, 255, 0.35);
+  border-radius: 0.7rem;
+  background: rgba(0, 200, 255, 0.1);
+  color: #61e4ff;
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.step-heading h2,
+.payload-card h2 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.step-heading p {
+  margin: 0.3rem 0 0;
+  color: #8196ae;
+  font-size: 0.83rem;
+}
+
+.space-form {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) auto minmax(18rem, 1.4fr);
+  align-items: end;
+  gap: 0.8rem;
+}
+
+label {
+  display: grid;
+  gap: 0.42rem;
+  color: #9db1c8;
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 2.7rem;
+  border: 1px solid rgba(135, 181, 218, 0.2);
+  border-radius: 0.7rem;
+  padding: 0.65rem 0.75rem;
+  background: rgba(2, 8, 16, 0.72);
+  color: #eff8ff;
+  outline: none;
+}
+
+input:focus,
+select:focus {
+  border-color: rgba(0, 212, 255, 0.68);
+  box-shadow: 0 0 0 3px rgba(0, 200, 255, 0.1);
+}
+
+button {
+  min-height: 2.7rem;
+  border: 1px solid rgba(0, 212, 255, 0.35);
+  border-radius: 0.7rem;
+  padding: 0.65rem 1rem;
+  background: rgba(0, 200, 255, 0.12);
+  color: #dffaff;
+  font-weight: 720;
+}
+
+button:hover:not(:disabled) {
+  background: rgba(0, 200, 255, 0.2);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.editor-section {
+  margin-top: 2.5rem;
+}
+
+.registration-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(18rem, 0.8fr);
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.registration-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(12rem, 0.6fr) auto;
+  align-items: end;
+  gap: 0.8rem;
+}
+
+.primary-action {
+  background: linear-gradient(135deg, #00c4f5, #0079ff);
+  color: #03101b;
+  border-color: transparent;
+}
+
+.message {
+  display: grid;
+  gap: 0.3rem;
+  margin-top: 1rem;
+  border-radius: 0.75rem;
+  padding: 0.8rem;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.message.error {
+  border: 1px solid rgba(255, 100, 116, 0.32);
+  background: rgba(255, 77, 99, 0.1);
+  color: #ffbdc5;
+}
+
+.message.success {
+  border: 1px solid rgba(77, 255, 167, 0.26);
+  background: rgba(77, 255, 167, 0.08);
+  color: #c7ffe2;
+}
+
+.payload-card {
+  padding: 1.4rem;
+}
+
+.payload-card h2 {
+  margin-top: 0.35rem;
+}
+
+.payload-card dl {
+  display: grid;
+  gap: 0;
+  margin: 1.2rem 0 0;
+}
+
+.payload-card dl div {
+  padding: 0.9rem 0;
+  border-top: 1px solid rgba(126, 238, 255, 0.1);
+}
+
+.payload-card dt {
+  margin-bottom: 0.28rem;
+  color: #6f879f;
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.payload-card dd {
+  margin: 0;
+  color: #dfeeff;
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 980px) {
+  .space-form,
+  .registration-form,
+  .registration-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .space-id-field {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 700px) {
+  .page-shell {
+    width: min(100% - 1rem, 92rem);
+    padding-top: 1.5rem;
+  }
+
+  .hero {
+    display: grid;
+  }
+
+  .hero h1 {
+    font-size: clamp(2rem, 12vw, 3.2rem);
+  }
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -23,7 +23,7 @@
       </div>
     </div>
 
-    <form [formGroup]="form" class="space-form" (ngSubmit)="createSpace()">
+    <form [formGroup]="spaceForm" class="space-form" (ngSubmit)="createSpace()">
       <label>
         Nombre del espacio
         <input formControlName="spaceName" autocomplete="off" />
@@ -59,7 +59,7 @@
         </div>
       </div>
 
-      <form [formGroup]="form" class="registration-form" (ngSubmit)="saveFurniture()">
+      <form [formGroup]="furnitureForm" class="registration-form" (ngSubmit)="saveFurniture()">
         <label>
           Nombre del mueble
           <input formControlName="furnitureName" autocomplete="off" />
@@ -72,7 +72,11 @@
             }
           </select>
         </label>
-        <button type="submit" class="primary-action" [disabled]="form.invalid || savingFurniture()">
+        <button
+          type="submit"
+          class="primary-action"
+          [disabled]="spaceForm.controls.spaceId.invalid || furnitureForm.invalid || savingFurniture()"
+        >
           {{ savingFurniture() ? 'Registrando…' : 'Registrar mueble' }}
         </button>
       </form>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,123 @@
+<main class="page-shell">
+  <header class="hero">
+    <div>
+      <p class="eyebrow">AR Home · Spatial core</p>
+      <h1>Delimita el mueble antes de intentar reconocerlo</h1>
+      <p class="hero-copy">
+        Define un volumen orientado, confirma su posición en el espacio y registra una identidad física estable.
+        La visión se añadirá después como ayuda de relocalización, no como única fuente de verdad.
+      </p>
+    </div>
+    <div class="status-badge">
+      <span></span>
+      Vertical slice 2
+    </div>
+  </header>
+
+  <section class="workflow-card">
+    <div class="step-heading">
+      <span>01</span>
+      <div>
+        <h2>Selecciona el espacio</h2>
+        <p>Crea uno nuevo o pega el UUID de uno existente.</p>
+      </div>
+    </div>
+
+    <form [formGroup]="form" class="space-form" (ngSubmit)="createSpace()">
+      <label>
+        Nombre del espacio
+        <input formControlName="spaceName" autocomplete="off" />
+      </label>
+      <button type="submit" [disabled]="creatingSpace()">
+        {{ creatingSpace() ? 'Creando…' : 'Crear espacio' }}
+      </button>
+      <label class="space-id-field">
+        Space ID
+        <input formControlName="spaceId" placeholder="UUID devuelto por la API" autocomplete="off" />
+      </label>
+    </form>
+  </section>
+
+  <section class="editor-section">
+    <div class="step-heading">
+      <span>02</span>
+      <div>
+        <h2>Ajusta la caja tridimensional</h2>
+        <p>Mueve, gira y escala el volumen. Los datos se convierten directamente al contrato del backend.</p>
+      </div>
+    </div>
+    <arh-furniture-box-editor (editorChange)="onEditorChange($event)" />
+  </section>
+
+  <section class="registration-grid">
+    <div class="workflow-card">
+      <div class="step-heading">
+        <span>03</span>
+        <div>
+          <h2>Registra la identidad</h2>
+          <p>El alta se guarda con reconocimiento manual asistido y confianza completa.</p>
+        </div>
+      </div>
+
+      <form [formGroup]="form" class="registration-form" (ngSubmit)="saveFurniture()">
+        <label>
+          Nombre del mueble
+          <input formControlName="furnitureName" autocomplete="off" />
+        </label>
+        <label>
+          Categoría
+          <select formControlName="category">
+            @for (category of categories; track category.value) {
+              <option [value]="category.value">{{ category.label }}</option>
+            }
+          </select>
+        </label>
+        <button type="submit" class="primary-action" [disabled]="form.invalid || savingFurniture()">
+          {{ savingFurniture() ? 'Registrando…' : 'Registrar mueble' }}
+        </button>
+      </form>
+
+      @if (errorMessage(); as error) {
+        <div class="message error" role="alert">{{ error }}</div>
+      }
+
+      @if (createdFurniture(); as furniture) {
+        <div class="message success">
+          <strong>Mueble registrado</strong>
+          <span>{{ furniture.id }}</span>
+        </div>
+      }
+    </div>
+
+    <aside class="payload-card">
+      <p class="eyebrow">Payload en tiempo real</p>
+      <h2>Pose y dimensiones</h2>
+      <dl>
+        <div>
+          <dt>Posición</dt>
+          <dd>
+            X {{ format(editorState.spaceTransform.translation.x) }} ·
+            Y {{ format(editorState.spaceTransform.translation.y) }} ·
+            Z {{ format(editorState.spaceTransform.translation.z) }}
+          </dd>
+        </div>
+        <div>
+          <dt>Dimensiones</dt>
+          <dd>
+            {{ format(editorState.bounds.width) }} ×
+            {{ format(editorState.bounds.height) }} ×
+            {{ format(editorState.bounds.depth) }} m
+          </dd>
+        </div>
+        <div>
+          <dt>Rotación Y</dt>
+          <dd>{{ format(editorState.yawDegrees) }}°</dd>
+        </div>
+        <div>
+          <dt>Método</dt>
+          <dd>MANUAL_BOUNDING_BOX</dd>
+        </div>
+      </dl>
+    </aside>
+  </section>
+</main>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -29,7 +29,8 @@ export class AppComponent {
     { value: 'OTHER', label: 'Otro' }
   ];
 
-  readonly form;
+  readonly spaceForm;
+  readonly furnitureForm;
   readonly creatingSpace = signal(false);
   readonly savingFurniture = signal(false);
   readonly createdFurniture = signal<FurnitureInstanceDto | null>(null);
@@ -48,9 +49,11 @@ export class AppComponent {
     formBuilder: FormBuilder,
     private readonly spatialApi: SpatialApiService
   ) {
-    this.form = formBuilder.nonNullable.group({
+    this.spaceForm = formBuilder.nonNullable.group({
       spaceName: ['Vivienda principal', [Validators.required, Validators.maxLength(120)]],
-      spaceId: ['', [Validators.required]],
+      spaceId: ['', [Validators.required]]
+    });
+    this.furnitureForm = formBuilder.nonNullable.group({
       furnitureName: ['Armario dormitorio', [Validators.required, Validators.maxLength(120)]],
       category: ['WARDROBE', [Validators.required]]
     });
@@ -61,7 +64,7 @@ export class AppComponent {
   }
 
   createSpace(): void {
-    const spaceName = this.form.controls.spaceName.value.trim();
+    const spaceName = this.spaceForm.controls.spaceName.value.trim();
     if (!spaceName || this.creatingSpace()) {
       return;
     }
@@ -73,21 +76,26 @@ export class AppComponent {
       .pipe(finalize(() => this.creatingSpace.set(false)))
       .subscribe({
         next: (space) => {
-          this.form.controls.spaceId.setValue(space.id);
-          this.form.controls.spaceId.markAsDirty();
+          this.spaceForm.controls.spaceId.setValue(space.id);
+          this.spaceForm.controls.spaceId.markAsDirty();
         },
         error: (error: unknown) => this.errorMessage.set(this.readError(error))
       });
   }
 
   saveFurniture(): void {
-    this.form.markAllAsTouched();
-    if (this.form.invalid || this.savingFurniture()) {
+    this.spaceForm.controls.spaceId.markAsTouched();
+    this.furnitureForm.markAllAsTouched();
+    if (
+      this.spaceForm.controls.spaceId.invalid ||
+      this.furnitureForm.invalid ||
+      this.savingFurniture()
+    ) {
       return;
     }
 
-    const spaceId = this.form.controls.spaceId.value.trim();
-    const furnitureName = this.form.controls.furnitureName.value.trim();
+    const spaceId = this.spaceForm.controls.spaceId.value.trim();
+    const furnitureName = this.furnitureForm.controls.furnitureName.value.trim();
     this.errorMessage.set(null);
     this.createdFurniture.set(null);
     this.savingFurniture.set(true);
@@ -95,7 +103,7 @@ export class AppComponent {
     this.spatialApi
       .registerFurniture(spaceId, {
         name: furnitureName,
-        category: this.form.controls.category.value,
+        category: this.furnitureForm.controls.category.value,
         spaceTransform: this.editorState.spaceTransform,
         bounds: this.editorState.bounds,
         recognitionMode: 'MANUAL_BOUNDING_BOX',

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,132 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { finalize } from 'rxjs';
+
+import { FurnitureBoxEditorComponent } from './furniture-box-editor.component';
+import { SpatialApiService } from './spatial-api.service';
+import {
+  FurnitureEditorState,
+  FurnitureInstanceDto,
+  IDENTITY_TRANSFORM
+} from './spatial.models';
+
+@Component({
+  selector: 'arh-root',
+  standalone: true,
+  imports: [ReactiveFormsModule, FurnitureBoxEditorComponent],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AppComponent {
+  readonly categories = [
+    { value: 'WARDROBE', label: 'Armario' },
+    { value: 'CABINET', label: 'Mueble / gabinete' },
+    { value: 'SHELVING', label: 'Estantería' },
+    { value: 'DRAWER_UNIT', label: 'Cajonera' },
+    { value: 'DESK', label: 'Escritorio' },
+    { value: 'OTHER', label: 'Otro' }
+  ];
+
+  readonly form;
+  readonly creatingSpace = signal(false);
+  readonly savingFurniture = signal(false);
+  readonly createdFurniture = signal<FurnitureInstanceDto | null>(null);
+  readonly errorMessage = signal<string | null>(null);
+
+  editorState: FurnitureEditorState = {
+    spaceTransform: {
+      translation: { x: 0, y: 1.1, z: 0 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 }
+    },
+    bounds: { width: 2, height: 2.2, depth: 0.6 },
+    yawDegrees: 0
+  };
+
+  constructor(
+    formBuilder: FormBuilder,
+    private readonly spatialApi: SpatialApiService
+  ) {
+    this.form = formBuilder.nonNullable.group({
+      spaceName: ['Vivienda principal', [Validators.required, Validators.maxLength(120)]],
+      spaceId: ['', [Validators.required]],
+      furnitureName: ['Armario dormitorio', [Validators.required, Validators.maxLength(120)]],
+      category: ['WARDROBE', [Validators.required]]
+    });
+  }
+
+  onEditorChange(state: FurnitureEditorState): void {
+    this.editorState = state;
+  }
+
+  createSpace(): void {
+    const spaceName = this.form.controls.spaceName.value.trim();
+    if (!spaceName || this.creatingSpace()) {
+      return;
+    }
+
+    this.errorMessage.set(null);
+    this.creatingSpace.set(true);
+    this.spatialApi
+      .createSpace({ name: spaceName, worldTransform: IDENTITY_TRANSFORM })
+      .pipe(finalize(() => this.creatingSpace.set(false)))
+      .subscribe({
+        next: (space) => {
+          this.form.controls.spaceId.setValue(space.id);
+          this.form.controls.spaceId.markAsDirty();
+        },
+        error: (error: unknown) => this.errorMessage.set(this.readError(error))
+      });
+  }
+
+  saveFurniture(): void {
+    this.form.markAllAsTouched();
+    if (this.form.invalid || this.savingFurniture()) {
+      return;
+    }
+
+    const spaceId = this.form.controls.spaceId.value.trim();
+    const furnitureName = this.form.controls.furnitureName.value.trim();
+    this.errorMessage.set(null);
+    this.createdFurniture.set(null);
+    this.savingFurniture.set(true);
+
+    this.spatialApi
+      .registerFurniture(spaceId, {
+        name: furnitureName,
+        category: this.form.controls.category.value,
+        spaceTransform: this.editorState.spaceTransform,
+        bounds: this.editorState.bounds,
+        recognitionMode: 'MANUAL_BOUNDING_BOX',
+        confidence: 1,
+        visualDescriptor: null
+      })
+      .pipe(finalize(() => this.savingFurniture.set(false)))
+      .subscribe({
+        next: (furniture) => this.createdFurniture.set(furniture),
+        error: (error: unknown) => this.errorMessage.set(this.readError(error))
+      });
+  }
+
+  format(value: number): string {
+    return new Intl.NumberFormat('es-ES', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 3
+    }).format(value);
+  }
+
+  private readError(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      const detail = error.error as { detail?: string; title?: string } | string | null;
+      if (typeof detail === 'string' && detail.trim()) {
+        return detail;
+      }
+      if (detail && typeof detail === 'object') {
+        return detail.detail ?? detail.title ?? `Error HTTP ${error.status}`;
+      }
+      return error.message || `Error HTTP ${error.status}`;
+    }
+    return error instanceof Error ? error.message : 'No se pudo completar la operación.';
+  }
+}

--- a/frontend/src/app/furniture-box-editor.component.css
+++ b/frontend/src/app/furniture-box-editor.component.css
@@ -1,0 +1,178 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.editor-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 17rem;
+  min-height: 39rem;
+  overflow: hidden;
+  border: 1px solid rgba(126, 238, 255, 0.18);
+  border-radius: 1.25rem;
+  background: rgba(7, 17, 30, 0.9);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.28);
+}
+
+.viewport {
+  position: relative;
+  min-height: 39rem;
+  overflow: hidden;
+}
+
+.viewport canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.mode-toolbar {
+  position: absolute;
+  z-index: 2;
+  top: 1rem;
+  left: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.9rem;
+  background: rgba(4, 10, 19, 0.82);
+  backdrop-filter: blur(14px);
+}
+
+button {
+  border: 1px solid transparent;
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.8rem;
+  background: transparent;
+  color: #b9cce3;
+}
+
+button:hover,
+button.active {
+  border-color: rgba(0, 212, 255, 0.45);
+  background: rgba(0, 200, 255, 0.16);
+  color: #ffffff;
+}
+
+button.secondary {
+  color: #93a7bf;
+}
+
+.viewport-hint {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 2;
+  width: fit-content;
+  max-width: calc(100% - 2rem);
+  padding: 0.55rem 0.8rem;
+  border-radius: 0.7rem;
+  background: rgba(4, 10, 19, 0.7);
+  color: #91a6bf;
+  font-size: 0.78rem;
+  backdrop-filter: blur(10px);
+}
+
+.numeric-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.35rem;
+  border-left: 1px solid rgba(126, 238, 255, 0.14);
+  background: linear-gradient(180deg, rgba(13, 27, 45, 0.94), rgba(7, 17, 30, 0.98));
+}
+
+.numeric-panel header h2 {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 1.15rem;
+}
+
+.numeric-panel header p:last-child {
+  margin: 0;
+  color: #849ab3;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #42ddff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.field-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.position-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+label {
+  display: grid;
+  gap: 0.38rem;
+  color: #9eb2ca;
+  font-size: 0.76rem;
+  font-weight: 650;
+}
+
+input {
+  min-width: 0;
+  width: 100%;
+  border: 1px solid rgba(135, 181, 218, 0.2);
+  border-radius: 0.65rem;
+  padding: 0.62rem 0.7rem;
+  background: rgba(2, 8, 16, 0.7);
+  color: #eff8ff;
+  outline: none;
+}
+
+input:focus {
+  border-color: rgba(0, 212, 255, 0.68);
+  box-shadow: 0 0 0 3px rgba(0, 200, 255, 0.1);
+}
+
+.input-with-unit {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.input-with-unit span {
+  color: #6f879f;
+}
+
+@media (max-width: 980px) {
+  .editor-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .numeric-panel {
+    border-top: 1px solid rgba(126, 238, 255, 0.14);
+    border-left: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .editor-shell,
+  .viewport {
+    min-height: 31rem;
+  }
+
+  .mode-toolbar {
+    right: 0.75rem;
+    left: 0.75rem;
+  }
+
+  .viewport-hint {
+    display: none;
+  }
+}

--- a/frontend/src/app/furniture-box-editor.component.html
+++ b/frontend/src/app/furniture-box-editor.component.html
@@ -1,0 +1,66 @@
+<section class="editor-shell" aria-label="Editor tridimensional del mueble">
+  <div class="viewport" #viewport>
+    <div class="mode-toolbar" role="toolbar" aria-label="Modo de transformación">
+      <button type="button" [class.active]="mode === 'translate'" (click)="setMode('translate')">
+        Mover
+      </button>
+      <button type="button" [class.active]="mode === 'rotate'" (click)="setMode('rotate')">
+        Girar
+      </button>
+      <button type="button" [class.active]="mode === 'scale'" (click)="setMode('scale')">
+        Escalar
+      </button>
+      <button type="button" class="secondary" (click)="reset()">Reiniciar</button>
+    </div>
+
+    <div class="viewport-hint">
+      Arrastra el gizmo · rueda/pinza para zoom · arrastra el fondo para orbitar
+    </div>
+  </div>
+
+  <aside class="numeric-panel">
+    <header>
+      <p class="eyebrow">Bounding box orientado</p>
+      <h2>Ajuste preciso</h2>
+      <p>Las medidas están expresadas en metros y la posición corresponde al centro del volumen.</p>
+    </header>
+
+    <div class="field-grid">
+      <label>
+        Ancho
+        <input type="number" min="0.1" max="20" step="0.05" [(ngModel)]="width" (change)="applyNumericState()" />
+      </label>
+      <label>
+        Alto
+        <input type="number" min="0.1" max="20" step="0.05" [(ngModel)]="height" (change)="applyNumericState()" />
+      </label>
+      <label>
+        Fondo
+        <input type="number" min="0.1" max="20" step="0.05" [(ngModel)]="depth" (change)="applyNumericState()" />
+      </label>
+    </div>
+
+    <div class="field-grid position-grid">
+      <label>
+        X
+        <input type="number" step="0.05" [(ngModel)]="positionX" (change)="applyNumericState()" />
+      </label>
+      <label>
+        Y
+        <input type="number" step="0.05" [(ngModel)]="positionY" (change)="applyNumericState()" />
+      </label>
+      <label>
+        Z
+        <input type="number" step="0.05" [(ngModel)]="positionZ" (change)="applyNumericState()" />
+      </label>
+    </div>
+
+    <label>
+      Giro vertical
+      <div class="input-with-unit">
+        <input type="number" step="1" [(ngModel)]="yawDegrees" (change)="applyNumericState()" />
+        <span>°</span>
+      </div>
+    </label>
+  </aside>
+</section>

--- a/frontend/src/app/furniture-box-editor.component.ts
+++ b/frontend/src/app/furniture-box-editor.component.ts
@@ -1,0 +1,287 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  OnDestroy,
+  Output,
+  ViewChild
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { TransformControls } from 'three/addons/controls/TransformControls.js';
+
+import { FurnitureEditorState } from './spatial.models';
+
+type TransformMode = 'translate' | 'rotate' | 'scale';
+
+@Component({
+  selector: 'arh-furniture-box-editor',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './furniture-box-editor.component.html',
+  styleUrl: './furniture-box-editor.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('viewport', { static: true })
+  private readonly viewportRef!: ElementRef<HTMLDivElement>;
+
+  @Output() readonly editorChange = new EventEmitter<FurnitureEditorState>();
+
+  mode: TransformMode = 'translate';
+  positionX = 0;
+  positionY = 1.1;
+  positionZ = 0;
+  yawDegrees = 0;
+  width = 2;
+  height = 2.2;
+  depth = 0.6;
+
+  private scene?: THREE.Scene;
+  private camera?: THREE.PerspectiveCamera;
+  private renderer?: THREE.WebGLRenderer;
+  private orbitControls?: OrbitControls;
+  private transformControls?: TransformControls;
+  private furnitureMesh?: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
+  private resizeObserver?: ResizeObserver;
+
+  ngAfterViewInit(): void {
+    this.initializeScene();
+    this.emitState();
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+    this.renderer?.setAnimationLoop(null);
+    this.orbitControls?.dispose();
+    this.transformControls?.dispose();
+
+    if (this.furnitureMesh) {
+      this.furnitureMesh.geometry.dispose();
+      this.furnitureMesh.material.dispose();
+      this.furnitureMesh.children.forEach((child) => {
+        if (child instanceof THREE.LineSegments) {
+          child.geometry.dispose();
+          const materials = Array.isArray(child.material) ? child.material : [child.material];
+          materials.forEach((material) => material.dispose());
+        }
+      });
+    }
+
+    this.renderer?.dispose();
+    this.renderer?.domElement.remove();
+  }
+
+  setMode(mode: TransformMode): void {
+    this.mode = mode;
+    this.transformControls?.setMode(mode);
+  }
+
+  applyNumericState(): void {
+    if (!this.furnitureMesh) {
+      return;
+    }
+
+    this.width = this.clampDimension(this.width);
+    this.height = this.clampDimension(this.height);
+    this.depth = this.clampDimension(this.depth);
+    this.positionX = this.finiteOrZero(this.positionX);
+    this.positionY = this.finiteOrZero(this.positionY);
+    this.positionZ = this.finiteOrZero(this.positionZ);
+    this.yawDegrees = this.finiteOrZero(this.yawDegrees);
+
+    this.furnitureMesh.position.set(this.positionX, this.positionY, this.positionZ);
+    this.furnitureMesh.quaternion.setFromEuler(
+      new THREE.Euler(0, THREE.MathUtils.degToRad(this.yawDegrees), 0, 'YXZ')
+    );
+    this.furnitureMesh.scale.set(this.width, this.height, this.depth);
+    this.emitState();
+  }
+
+  reset(): void {
+    this.width = 2;
+    this.height = 2.2;
+    this.depth = 0.6;
+    this.positionX = 0;
+    this.positionY = this.height / 2;
+    this.positionZ = 0;
+    this.yawDegrees = 0;
+    this.applyNumericState();
+
+    if (this.camera && this.orbitControls) {
+      this.camera.position.set(4, 3, 5);
+      this.orbitControls.target.set(0, 1, 0);
+      this.orbitControls.update();
+    }
+  }
+
+  private initializeScene(): void {
+    const viewport = this.viewportRef.nativeElement;
+
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color(0x07111e);
+    this.scene.fog = new THREE.Fog(0x07111e, 10, 24);
+
+    this.camera = new THREE.PerspectiveCamera(50, 1, 0.05, 100);
+    this.camera.position.set(4, 3, 5);
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    viewport.appendChild(this.renderer.domElement);
+
+    const hemisphereLight = new THREE.HemisphereLight(0xb9e8ff, 0x172032, 2.2);
+    this.scene.add(hemisphereLight);
+
+    const keyLight = new THREE.DirectionalLight(0xffffff, 3.2);
+    keyLight.position.set(3, 6, 4);
+    keyLight.castShadow = true;
+    this.scene.add(keyLight);
+
+    const floorGeometry = new THREE.PlaneGeometry(12, 12);
+    const floorMaterial = new THREE.MeshStandardMaterial({
+      color: 0x0d1a2a,
+      roughness: 0.92,
+      metalness: 0.05
+    });
+    const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+    floor.rotation.x = -Math.PI / 2;
+    floor.receiveShadow = true;
+    this.scene.add(floor);
+
+    const grid = new THREE.GridHelper(12, 24, 0x34d6ff, 0x244158);
+    grid.position.y = 0.002;
+    this.scene.add(grid);
+
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshStandardMaterial({
+      color: 0x00c8ff,
+      transparent: true,
+      opacity: 0.28,
+      roughness: 0.35,
+      metalness: 0.1
+    });
+
+    this.furnitureMesh = new THREE.Mesh(geometry, material);
+    this.furnitureMesh.castShadow = true;
+    this.furnitureMesh.position.set(this.positionX, this.positionY, this.positionZ);
+    this.furnitureMesh.scale.set(this.width, this.height, this.depth);
+
+    const edgesGeometry = new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1));
+    const edgesMaterial = new THREE.LineBasicMaterial({ color: 0x7eeeff });
+    const edges = new THREE.LineSegments(edgesGeometry, edgesMaterial);
+    this.furnitureMesh.add(edges);
+    this.scene.add(this.furnitureMesh);
+
+    this.orbitControls = new OrbitControls(this.camera, this.renderer.domElement);
+    this.orbitControls.enableDamping = true;
+    this.orbitControls.dampingFactor = 0.08;
+    this.orbitControls.target.set(0, 1, 0);
+    this.orbitControls.maxPolarAngle = Math.PI / 2 - 0.02;
+    this.orbitControls.minDistance = 1.2;
+    this.orbitControls.maxDistance = 15;
+
+    this.transformControls = new TransformControls(this.camera, this.renderer.domElement);
+    this.transformControls.setMode(this.mode);
+    this.transformControls.setSpace('local');
+    this.transformControls.setTranslationSnap(0.05);
+    this.transformControls.setRotationSnap(THREE.MathUtils.degToRad(5));
+    this.transformControls.setScaleSnap(0.05);
+    this.transformControls.attach(this.furnitureMesh);
+    this.scene.add(this.transformControls.getHelper());
+
+    this.transformControls.addEventListener('dragging-changed', (event) => {
+      if (this.orbitControls) {
+        this.orbitControls.enabled = !(event as unknown as { value: boolean }).value;
+      }
+    });
+    this.transformControls.addEventListener('objectChange', () => this.syncFromMesh());
+
+    this.resizeObserver = new ResizeObserver(() => this.resize());
+    this.resizeObserver.observe(viewport);
+    this.resize();
+
+    this.renderer.setAnimationLoop(() => {
+      this.orbitControls?.update();
+      if (this.scene && this.camera) {
+        this.renderer?.render(this.scene, this.camera);
+      }
+    });
+  }
+
+  private resize(): void {
+    if (!this.renderer || !this.camera) {
+      return;
+    }
+
+    const viewport = this.viewportRef.nativeElement;
+    const width = Math.max(viewport.clientWidth, 1);
+    const height = Math.max(viewport.clientHeight, 1);
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(width, height, false);
+  }
+
+  private syncFromMesh(): void {
+    if (!this.furnitureMesh) {
+      return;
+    }
+
+    this.positionX = this.round(this.furnitureMesh.position.x);
+    this.positionY = this.round(this.furnitureMesh.position.y);
+    this.positionZ = this.round(this.furnitureMesh.position.z);
+    this.width = this.clampDimension(Math.abs(this.furnitureMesh.scale.x));
+    this.height = this.clampDimension(Math.abs(this.furnitureMesh.scale.y));
+    this.depth = this.clampDimension(Math.abs(this.furnitureMesh.scale.z));
+
+    const euler = new THREE.Euler().setFromQuaternion(this.furnitureMesh.quaternion, 'YXZ');
+    this.yawDegrees = this.round(THREE.MathUtils.radToDeg(euler.y), 1);
+    this.emitState();
+  }
+
+  private emitState(): void {
+    if (!this.furnitureMesh) {
+      return;
+    }
+
+    const quaternion = this.furnitureMesh.quaternion.clone().normalize();
+    this.editorChange.emit({
+      spaceTransform: {
+        translation: {
+          x: this.round(this.furnitureMesh.position.x),
+          y: this.round(this.furnitureMesh.position.y),
+          z: this.round(this.furnitureMesh.position.z)
+        },
+        rotation: {
+          x: this.round(quaternion.x, 6),
+          y: this.round(quaternion.y, 6),
+          z: this.round(quaternion.z, 6),
+          w: this.round(quaternion.w, 6)
+        }
+      },
+      bounds: {
+        width: this.clampDimension(Math.abs(this.furnitureMesh.scale.x)),
+        height: this.clampDimension(Math.abs(this.furnitureMesh.scale.y)),
+        depth: this.clampDimension(Math.abs(this.furnitureMesh.scale.z))
+      },
+      yawDegrees: this.yawDegrees
+    });
+  }
+
+  private clampDimension(value: number): number {
+    return this.round(Math.min(Math.max(Number.isFinite(value) ? Math.abs(value) : 0.1, 0.1), 20));
+  }
+
+  private finiteOrZero(value: number): number {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  private round(value: number, digits = 3): number {
+    const factor = 10 ** digits;
+    return Math.round(value * factor) / factor;
+  }
+}

--- a/frontend/src/app/furniture-box-editor.component.ts
+++ b/frontend/src/app/furniture-box-editor.component.ts
@@ -1,12 +1,15 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
+  NgZone,
   OnDestroy,
   Output,
-  ViewChild
+  ViewChild,
+  inject
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import * as THREE from 'three';
@@ -16,6 +19,11 @@ import { TransformControls } from 'three/addons/controls/TransformControls.js';
 import { FurnitureEditorState } from './spatial.models';
 
 type TransformMode = 'translate' | 'rotate' | 'scale';
+
+type DisposableRenderable = THREE.Object3D & {
+  geometry?: THREE.BufferGeometry;
+  material?: THREE.Material | THREE.Material[];
+};
 
 @Component({
   selector: 'arh-furniture-box-editor',
@@ -40,6 +48,8 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   height = 2.2;
   depth = 0.6;
 
+  private readonly changeDetector = inject(ChangeDetectorRef);
+  private readonly ngZone = inject(NgZone);
   private scene?: THREE.Scene;
   private camera?: THREE.PerspectiveCamera;
   private renderer?: THREE.WebGLRenderer;
@@ -49,7 +59,7 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   private resizeObserver?: ResizeObserver;
 
   ngAfterViewInit(): void {
-    this.initializeScene();
+    this.ngZone.runOutsideAngular(() => this.initializeScene());
     this.emitState();
   }
 
@@ -59,17 +69,16 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     this.orbitControls?.dispose();
     this.transformControls?.dispose();
 
-    if (this.furnitureMesh) {
-      this.furnitureMesh.geometry.dispose();
-      this.furnitureMesh.material.dispose();
-      this.furnitureMesh.children.forEach((child) => {
-        if (child instanceof THREE.LineSegments) {
-          child.geometry.dispose();
-          const materials = Array.isArray(child.material) ? child.material : [child.material];
-          materials.forEach((material) => material.dispose());
-        }
-      });
-    }
+    this.scene?.traverse((object) => {
+      const renderable = object as DisposableRenderable;
+      renderable.geometry?.dispose();
+      const materials = renderable.material
+        ? Array.isArray(renderable.material)
+          ? renderable.material
+          : [renderable.material]
+        : [];
+      materials.forEach((material) => material.dispose());
+    });
 
     this.renderer?.dispose();
     this.renderer?.domElement.remove();
@@ -142,13 +151,14 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     keyLight.castShadow = true;
     this.scene.add(keyLight);
 
-    const floorGeometry = new THREE.PlaneGeometry(12, 12);
-    const floorMaterial = new THREE.MeshStandardMaterial({
-      color: 0x0d1a2a,
-      roughness: 0.92,
-      metalness: 0.05
-    });
-    const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+    const floor = new THREE.Mesh(
+      new THREE.PlaneGeometry(12, 12),
+      new THREE.MeshStandardMaterial({
+        color: 0x0d1a2a,
+        roughness: 0.92,
+        metalness: 0.05
+      })
+    );
     floor.rotation.x = -Math.PI / 2;
     floor.receiveShadow = true;
     this.scene.add(floor);
@@ -171,9 +181,13 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     this.furnitureMesh.position.set(this.positionX, this.positionY, this.positionZ);
     this.furnitureMesh.scale.set(this.width, this.height, this.depth);
 
-    const edgesGeometry = new THREE.EdgesGeometry(new THREE.BoxGeometry(1, 1, 1));
-    const edgesMaterial = new THREE.LineBasicMaterial({ color: 0x7eeeff });
-    const edges = new THREE.LineSegments(edgesGeometry, edgesMaterial);
+    const edgeSourceGeometry = new THREE.BoxGeometry(1, 1, 1);
+    const edgesGeometry = new THREE.EdgesGeometry(edgeSourceGeometry);
+    edgeSourceGeometry.dispose();
+    const edges = new THREE.LineSegments(
+      edgesGeometry,
+      new THREE.LineBasicMaterial({ color: 0x7eeeff })
+    );
     this.furnitureMesh.add(edges);
     this.scene.add(this.furnitureMesh);
 
@@ -199,7 +213,9 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
         this.orbitControls.enabled = !(event as unknown as { value: boolean }).value;
       }
     });
-    this.transformControls.addEventListener('objectChange', () => this.syncFromMesh());
+    this.transformControls.addEventListener('objectChange', () => {
+      this.ngZone.run(() => this.syncFromMesh());
+    });
 
     this.resizeObserver = new ResizeObserver(() => this.resize());
     this.resizeObserver.observe(viewport);
@@ -240,6 +256,7 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
 
     const euler = new THREE.Euler().setFromQuaternion(this.furnitureMesh.quaternion, 'YXZ');
     this.yawDegrees = this.round(THREE.MathUtils.radToDeg(euler.y), 1);
+    this.changeDetector.markForCheck();
     this.emitState();
   }
 

--- a/frontend/src/app/spatial-api.service.ts
+++ b/frontend/src/app/spatial-api.service.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import {
+  CreateSpaceRequest,
+  FurnitureInstanceDto,
+  RegisterFurnitureRequest,
+  SpaceDto
+} from './spatial.models';
+
+@Injectable({ providedIn: 'root' })
+export class SpatialApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = '/api/v1/spatial';
+
+  createSpace(request: CreateSpaceRequest): Observable<SpaceDto> {
+    return this.http.post<SpaceDto>(`${this.baseUrl}/spaces`, request);
+  }
+
+  registerFurniture(
+    spaceId: string,
+    request: RegisterFurnitureRequest
+  ): Observable<FurnitureInstanceDto> {
+    return this.http.post<FurnitureInstanceDto>(
+      `${this.baseUrl}/spaces/${encodeURIComponent(spaceId)}/furniture`,
+      request
+    );
+  }
+}

--- a/frontend/src/app/spatial.models.ts
+++ b/frontend/src/app/spatial.models.ts
@@ -1,0 +1,77 @@
+export interface Vector3Dto {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface QuaternionDto {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+}
+
+export interface Transform3DDto {
+  translation: Vector3Dto;
+  rotation: QuaternionDto;
+}
+
+export interface Bounds3DDto {
+  width: number;
+  height: number;
+  depth: number;
+}
+
+export interface SpaceDto {
+  id: string;
+  name: string;
+  worldTransform: Transform3DDto;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FurnitureInstanceDto {
+  id: string;
+  spaceId: string;
+  name: string;
+  category: string;
+  spaceTransform: Transform3DDto;
+  bounds: Bounds3DDto;
+  recognitionMode: RecognitionMode;
+  confidence: number;
+  visualDescriptor: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type RecognitionMode =
+  | 'MANUAL_BOUNDING_BOX'
+  | 'VISUAL_RELOCALIZATION'
+  | 'MARKER_ASSISTED'
+  | 'AUTOMATIC';
+
+export interface CreateSpaceRequest {
+  name: string;
+  worldTransform: Transform3DDto;
+}
+
+export interface RegisterFurnitureRequest {
+  name: string;
+  category: string;
+  spaceTransform: Transform3DDto;
+  bounds: Bounds3DDto;
+  recognitionMode: RecognitionMode;
+  confidence: number;
+  visualDescriptor: string | null;
+}
+
+export interface FurnitureEditorState {
+  spaceTransform: Transform3DDto;
+  bounds: Bounds3DDto;
+  yawDegrees: number;
+}
+
+export const IDENTITY_TRANSFORM: Transform3DDto = {
+  translation: { x: 0, y: 0, z: 0 },
+  rotation: { x: 0, y: 0, z: 0, w: 1 }
+};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>AR Home Furniture Editor</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#08111f" />
+  </head>
+  <body>
+    <arh-root></arh-root>
+  </body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,8 @@
+import { provideHttpClient } from '@angular/common/http';
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideHttpClient()]
+}).catch((error: unknown) => console.error(error));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,31 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #050b14;
+  color: #e8f1ff;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-width: 320px;
+  min-height: 100%;
+  margin: 0;
+  background:
+    radial-gradient(circle at 10% 0%, rgba(0, 229, 255, 0.12), transparent 32rem),
+    linear-gradient(180deg, #08111f 0%, #040810 100%);
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": ["@webgpu/types"]
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.d.ts"]

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022", "dom"]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}


### PR DESCRIPTION
## Objetivo

Añadir el segundo vertical slice de AR Home: una interfaz Angular + Three.js que permita delimitar manualmente un mueble y persistir su identidad mediante la API espacial ya existente.

## Qué incorpora

- Aplicación Angular standalone con TypeScript estricto.
- Visor Three.js responsive con suelo, cuadrícula e iluminación.
- Caja 3D orientada editable mediante `TransformControls`.
- Navegación de escena mediante `OrbitControls`.
- Modos mover, girar y escalar con snaps de 5 cm y 5 grados.
- Ajuste numérico de posición, dimensiones y giro vertical.
- Conversión de la escena a `Transform3D` y `Bounds3D`.
- Creación de espacios desde la interfaz.
- Registro real de `FurnitureInstance` con `MANUAL_BOUNDING_BOX`.
- Gestión de errores `ProblemDetail` y confirmación del UUID creado.
- Proxy local a Spring Boot y workflow de build de producción.
- Liberación de controles y recursos WebGL al destruir el componente.

## Decisión de alcance

Este PR no incluye cámara ni WebXR. Su unidad verificable es el editor geométrico y su integración con el backend. La superposición sobre cámara y la obtención de pose mediante hit-test se implementarán en incrementos separados para no mezclar interacción 3D, permisos multimedia y tracking espacial en una sola entrega.

## Validación

- El workflow `Frontend CI` instalará dependencias con Node.js 22 y ejecutará `npm run build:ci`.
- El contrato frontend replica directamente los records expuestos por `SpatialController`.

## Siguiente incremento

Captura móvil con `getUserMedia`, selección dinámica de cámara y superposición transparente del editor antes de activar WebXR.