### PR TITLE
feat: add live camera overlay for furniture fitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Implementado en `frontend/`:
 - Liberación explícita de controles y recursos WebGL.
 - Build de producción validado mediante GitHub Actions.
 
+### Vista previa sobre cámara
+
+- Captura mediante `navigator.mediaDevices.getUserMedia`.
+- Preferencia automática por la cámara trasera.
+- Selector de cámaras disponible después de conceder permisos.
+- Vídeo a pantalla completa con canvas Three.js transparente superpuesto.
+- Retícula, estado de captura y resolución activa.
+- Espejado automático para cámaras frontales.
+- Gestión explícita de errores de permiso, cámara ocupada y dispositivo no disponible.
+- Parada de todas las pistas al cerrar o cambiar al modo escena.
+- Diferenciación entre referencias `SPACE` y `CAMERA_PREVIEW`.
+- Bloqueo de persistencia para evitar guardar una pose relativa al visor como pose de habitación.
+
+La vista de cámara permite ajustar la geometría real del mueble, pero todavía no crea un anclaje espacial persistente. Ese paso corresponde al siguiente incremento WebXR.
+
 ## Jerarquía espacial
 
 ```text
@@ -75,6 +90,8 @@ npm start
 
 El proxy de desarrollo reenvía `/api` a `http://localhost:8080`. Abre `http://localhost:4200`.
 
+La cámara web requiere un contexto seguro: `localhost` durante desarrollo o HTTPS al acceder desde otro dispositivo. Abrir una IP local mediante HTTP normalmente no concede acceso a cámara.
+
 ## API espacial inicial
 
 ```text
@@ -106,8 +123,8 @@ GET  /api/v1/spatial/items/{itemId}/world-pose
 
 ## Próximos incrementos
 
-1. Captura móvil con `getUserMedia` y superposición del editor sobre la cámara.
-2. WebXR/ARCore para obtener pose y hit-test en dispositivos compatibles.
+1. WebXR `immersive-ar` con hit-test para situar la caja sobre una superficie real.
+2. Conversión de la pose WebXR a un sistema de referencia persistente del espacio.
 3. Persistencia de observaciones visuales y relocalización entre sesiones.
 4. Editor visual de cajones, baldas y otros compartimentos.
 5. Adaptador con Homestead Inventory y Home Assistant.

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -190,6 +190,7 @@ button:disabled {
   border-radius: 0.75rem;
   padding: 0.8rem;
   font-size: 0.8rem;
+  line-height: 1.45;
   overflow-wrap: anywhere;
 }
 
@@ -197,6 +198,16 @@ button:disabled {
   border: 1px solid rgba(255, 100, 116, 0.32);
   background: rgba(255, 77, 99, 0.1);
   color: #ffbdc5;
+}
+
+.message.warning {
+  border: 1px solid rgba(255, 190, 78, 0.3);
+  background: rgba(255, 174, 31, 0.08);
+  color: #ffe4b2;
+}
+
+.message.warning span {
+  color: #ccb991;
 }
 
 .message.success {

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -2,15 +2,15 @@
   <header class="hero">
     <div>
       <p class="eyebrow">AR Home · Spatial core</p>
-      <h1>Delimita el mueble antes de intentar reconocerlo</h1>
+      <h1>Encaja el volumen sobre el mueble real</h1>
       <p class="hero-copy">
-        Define un volumen orientado, confirma su posición en el espacio y registra una identidad física estable.
-        La visión se añadirá después como ayuda de relocalización, no como única fuente de verdad.
+        Abre la cámara trasera, superpone la caja tridimensional y ajusta su geometría directamente sobre la imagen.
+        La vista previa no se persiste como pose espacial hasta disponer de un anclaje WebXR válido.
       </p>
     </div>
     <div class="status-badge">
       <span></span>
-      Vertical slice 2
+      Vertical slice 3
     </div>
   </header>
 
@@ -43,7 +43,7 @@
       <span>02</span>
       <div>
         <h2>Ajusta la caja tridimensional</h2>
-        <p>Mueve, gira y escala el volumen. Los datos se convierten directamente al contrato del backend.</p>
+        <p>Alterna entre escena 3D y cámara. La geometría se mantiene en el contrato del backend.</p>
       </div>
     </div>
     <arh-furniture-box-editor (editorChange)="onEditorChange($event)" />
@@ -55,7 +55,7 @@
         <span>03</span>
         <div>
           <h2>Registra la identidad</h2>
-          <p>El alta se guarda con reconocimiento manual asistido y confianza completa.</p>
+          <p>Solo se permite persistir una pose expresada en el sistema de referencia del espacio.</p>
         </div>
       </div>
 
@@ -75,11 +75,32 @@
         <button
           type="submit"
           class="primary-action"
-          [disabled]="spaceForm.controls.spaceId.invalid || furnitureForm.invalid || savingFurniture()"
+          [disabled]="
+            spaceForm.controls.spaceId.invalid ||
+            furnitureForm.invalid ||
+            editorState.referenceFrame !== 'SPACE' ||
+            savingFurniture()
+          "
         >
-          {{ savingFurniture() ? 'Registrando…' : 'Registrar mueble' }}
+          {{
+            editorState.referenceFrame === 'CAMERA_PREVIEW'
+              ? 'Pendiente de anclaje'
+              : savingFurniture()
+                ? 'Registrando…'
+                : 'Registrar mueble'
+          }}
         </button>
       </form>
+
+      @if (editorState.referenceFrame === 'CAMERA_PREVIEW') {
+        <div class="message warning" role="status">
+          <strong>Pose no persistente</strong>
+          <span>
+            Puedes ajustar dimensiones sobre la cámara, pero el origen actual es el visor. El siguiente incremento
+            sustituirá esta referencia por un anclaje WebXR.
+          </span>
+        </div>
+      }
 
       @if (errorMessage(); as error) {
         <div class="message error" role="alert">{{ error }}</div>
@@ -97,6 +118,12 @@
       <p class="eyebrow">Payload en tiempo real</p>
       <h2>Pose y dimensiones</h2>
       <dl>
+        <div>
+          <dt>Sistema de referencia</dt>
+          <dd>
+            {{ editorState.referenceFrame === 'SPACE' ? 'Espacio persistente' : 'Vista previa de cámara' }}
+          </dd>
+        </div>
         <div>
           <dt>Posición</dt>
           <dd>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -42,7 +42,8 @@ export class AppComponent {
       rotation: { x: 0, y: 0, z: 0, w: 1 }
     },
     bounds: { width: 2, height: 2.2, depth: 0.6 },
-    yawDegrees: 0
+    yawDegrees: 0,
+    referenceFrame: 'SPACE'
   };
 
   constructor(
@@ -86,6 +87,14 @@ export class AppComponent {
   saveFurniture(): void {
     this.spaceForm.controls.spaceId.markAsTouched();
     this.furnitureForm.markAllAsTouched();
+
+    if (this.editorState.referenceFrame !== 'SPACE') {
+      this.errorMessage.set(
+        'La pose actual pertenece a una vista previa de cámara. Cambia a Escena 3D o espera al anclaje WebXR antes de registrar el mueble.'
+      );
+      return;
+    }
+
     if (
       this.spaceForm.controls.spaceId.invalid ||
       this.furnitureForm.invalid ||

--- a/frontend/src/app/camera-stream.service.ts
+++ b/frontend/src/app/camera-stream.service.ts
@@ -1,0 +1,144 @@
+import { Injectable } from '@angular/core';
+
+export interface CameraDevice {
+  deviceId: string;
+  label: string;
+}
+
+export interface CameraSession {
+  stream: MediaStream;
+  deviceId: string | null;
+  width: number | null;
+  height: number | null;
+  facingMode: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CameraStreamService {
+  private activeStream: MediaStream | null = null;
+
+  isSupported(): boolean {
+    return typeof navigator !== 'undefined' && Boolean(navigator.mediaDevices?.getUserMedia);
+  }
+
+  isSecureContext(): boolean {
+    return typeof window !== 'undefined' && window.isSecureContext;
+  }
+
+  async start(deviceId?: string): Promise<CameraSession> {
+    if (!this.isSupported()) {
+      throw new CameraAccessError(
+        'UNSUPPORTED',
+        'Este navegador no expone la API de cámara getUserMedia.'
+      );
+    }
+
+    this.stop();
+
+    const preferredConstraints: MediaTrackConstraints = deviceId
+      ? {
+          deviceId: { exact: deviceId },
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+          frameRate: { ideal: 30, max: 60 }
+        }
+      : {
+          facingMode: { ideal: 'environment' },
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+          frameRate: { ideal: 30, max: 60 }
+        };
+
+    try {
+      this.activeStream = await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: preferredConstraints
+      });
+    } catch (error: unknown) {
+      throw this.mapError(error);
+    }
+
+    const track = this.activeStream.getVideoTracks()[0];
+    if (!track) {
+      this.stop();
+      throw new CameraAccessError('NO_VIDEO_TRACK', 'La cámara no devolvió ninguna pista de vídeo.');
+    }
+
+    const settings = track.getSettings();
+    return {
+      stream: this.activeStream,
+      deviceId: settings.deviceId ?? null,
+      width: settings.width ?? null,
+      height: settings.height ?? null,
+      facingMode: settings.facingMode ?? null
+    };
+  }
+
+  async listVideoInputs(): Promise<CameraDevice[]> {
+    if (!this.isSupported()) {
+      return [];
+    }
+
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    let fallbackIndex = 1;
+    return devices
+      .filter((device) => device.kind === 'videoinput')
+      .map((device) => ({
+        deviceId: device.deviceId,
+        label: device.label.trim() || `Cámara ${fallbackIndex++}`
+      }));
+  }
+
+  stop(): void {
+    this.activeStream?.getTracks().forEach((track) => track.stop());
+    this.activeStream = null;
+  }
+
+  private mapError(error: unknown): CameraAccessError {
+    if (!(error instanceof DOMException)) {
+      return new CameraAccessError('UNKNOWN', 'No se pudo iniciar la cámara.', error);
+    }
+
+    switch (error.name) {
+      case 'NotAllowedError':
+      case 'SecurityError':
+        return new CameraAccessError(
+          'PERMISSION_DENIED',
+          'El permiso de cámara fue rechazado o la página no se está sirviendo en un contexto seguro.',
+          error
+        );
+      case 'NotFoundError':
+        return new CameraAccessError(
+          'NO_CAMERA',
+          'No se encontró ninguna cámara compatible.',
+          error
+        );
+      case 'NotReadableError':
+      case 'AbortError':
+        return new CameraAccessError(
+          'CAMERA_BUSY',
+          'La cámara está siendo utilizada por otra aplicación o no puede abrirse.',
+          error
+        );
+      case 'OverconstrainedError':
+        return new CameraAccessError(
+          'CONSTRAINTS',
+          'La cámara seleccionada no admite la configuración solicitada.',
+          error
+        );
+      default:
+        return new CameraAccessError('UNKNOWN', error.message || 'No se pudo iniciar la cámara.', error);
+    }
+  }
+}
+
+export class CameraAccessError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'CameraAccessError';
+  }
+}

--- a/frontend/src/app/camera-stream.service.ts
+++ b/frontend/src/app/camera-stream.service.ts
@@ -136,7 +136,7 @@ export class CameraAccessError extends Error {
   constructor(
     readonly code: string,
     message: string,
-    readonly cause?: unknown
+    readonly originalError?: unknown
   ) {
     super(message);
     this.name = 'CameraAccessError';

--- a/frontend/src/app/furniture-box-editor.component.css
+++ b/frontend/src/app/furniture-box-editor.component.css
@@ -18,19 +18,99 @@
   position: relative;
   min-height: 39rem;
   overflow: hidden;
+  background: #07111e;
+}
+
+.viewport.camera-mode {
+  background: #020407;
 }
 
 .viewport canvas {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
   display: block;
   width: 100%;
   height: 100%;
 }
 
+.camera-feed {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+
+.camera-feed.visible {
+  opacity: 1;
+}
+
+.camera-feed.mirrored {
+  transform: scaleX(-1);
+}
+
+.camera-vignette {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(0, 0, 0, 0.38), transparent 24%, transparent 72%, rgba(0, 0, 0, 0.48)),
+    radial-gradient(circle at center, transparent 48%, rgba(0, 0, 0, 0.24) 100%);
+}
+
+.camera-reticle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 3;
+  width: 2.6rem;
+  height: 2.6rem;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}
+
+.camera-reticle::before,
+.camera-reticle::after {
+  position: absolute;
+  content: '';
+  background: rgba(222, 249, 255, 0.65);
+  box-shadow: 0 0 0.45rem rgba(0, 208, 255, 0.42);
+}
+
+.camera-reticle::before {
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 1px;
+}
+
+.camera-reticle::after {
+  top: 0;
+  left: 50%;
+  width: 1px;
+  height: 100%;
+}
+
+.camera-reticle span {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.42rem;
+  height: 0.42rem;
+  border: 1px solid #c8f8ff;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.view-toolbar,
 .mode-toolbar {
   position: absolute;
-  z-index: 2;
-  top: 1rem;
-  left: 1rem;
+  z-index: 4;
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
@@ -41,7 +121,19 @@
   backdrop-filter: blur(14px);
 }
 
-button {
+.view-toolbar {
+  top: 1rem;
+  left: 1rem;
+}
+
+.mode-toolbar {
+  top: 4.65rem;
+  left: 1rem;
+}
+
+button,
+.camera-select {
+  min-height: 2.15rem;
   border: 1px solid transparent;
   border-radius: 0.65rem;
   padding: 0.55rem 0.8rem;
@@ -49,15 +141,57 @@ button {
   color: #b9cce3;
 }
 
-button:hover,
+button:hover:not(:disabled),
 button.active {
   border-color: rgba(0, 212, 255, 0.45);
   background: rgba(0, 200, 255, 0.16);
   color: #ffffff;
 }
 
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 button.secondary {
   color: #93a7bf;
+}
+
+.camera-select {
+  max-width: 15rem;
+  border-color: rgba(135, 181, 218, 0.2);
+  background: rgba(2, 8, 16, 0.85);
+  outline: none;
+}
+
+.camera-message {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 4;
+  max-width: min(26rem, calc(100% - 2rem));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.8rem;
+  background: rgba(4, 10, 19, 0.78);
+  font-size: 0.75rem;
+  line-height: 1.4;
+  backdrop-filter: blur(12px);
+}
+
+.camera-message.success {
+  border-color: rgba(77, 255, 167, 0.28);
+  color: #bfffdc;
+}
+
+.camera-message.warning {
+  border-color: rgba(255, 192, 84, 0.32);
+  color: #ffe0a8;
+}
+
+.camera-message.error {
+  border-color: rgba(255, 100, 116, 0.36);
+  color: #ffc0c8;
 }
 
 .viewport-hint {
@@ -65,7 +199,7 @@ button.secondary {
   right: 1rem;
   bottom: 1rem;
   left: 1rem;
-  z-index: 2;
+  z-index: 4;
   width: fit-content;
   max-width: calc(100% - 2rem);
   padding: 0.55rem 0.8rem;
@@ -106,6 +240,22 @@ button.secondary {
   text-transform: uppercase;
 }
 
+.reference-warning {
+  display: grid;
+  gap: 0.38rem;
+  border: 1px solid rgba(255, 190, 78, 0.22);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(255, 174, 31, 0.07);
+  color: #ffe5b6;
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.reference-warning span {
+  color: #c7b38f;
+}
+
 .field-grid {
   display: grid;
   gap: 0.75rem;
@@ -134,7 +284,8 @@ input {
   outline: none;
 }
 
-input:focus {
+input:focus,
+.camera-select:focus {
   border-color: rgba(0, 212, 255, 0.68);
   box-shadow: 0 0 0 3px rgba(0, 200, 255, 0.1);
 }
@@ -161,15 +312,34 @@ input:focus {
   }
 }
 
-@media (max-width: 640px) {
-  .editor-shell,
-  .viewport {
-    min-height: 31rem;
-  }
-
+@media (max-width: 720px) {
+  .view-toolbar,
   .mode-toolbar {
     right: 0.75rem;
     left: 0.75rem;
+  }
+
+  .mode-toolbar {
+    top: 4.4rem;
+  }
+
+  .camera-message {
+    top: auto;
+    right: 0.75rem;
+    bottom: 3.7rem;
+    left: 0.75rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .editor-shell,
+  .viewport {
+    min-height: 34rem;
+  }
+
+  .camera-select {
+    width: 100%;
+    max-width: none;
   }
 
   .viewport-hint {

--- a/frontend/src/app/furniture-box-editor.component.html
+++ b/frontend/src/app/furniture-box-editor.component.html
@@ -1,5 +1,54 @@
 <section class="editor-shell" aria-label="Editor tridimensional del mueble">
-  <div class="viewport" #viewport>
+  <div class="viewport" #viewport [class.camera-mode]="viewMode === 'camera'">
+    <video
+      #cameraVideo
+      class="camera-feed"
+      [class.visible]="cameraActive"
+      [class.mirrored]="mirrorVideo"
+      autoplay
+      muted
+      playsinline
+      aria-label="Vista previa de la cámara"
+    ></video>
+
+    @if (viewMode === 'camera') {
+      <div class="camera-vignette" aria-hidden="true"></div>
+      <div class="camera-reticle" aria-hidden="true">
+        <span></span>
+      </div>
+    }
+
+    <div class="view-toolbar" role="toolbar" aria-label="Fuente de visualización">
+      <button
+        type="button"
+        [class.active]="viewMode === 'scene'"
+        (click)="stopCamera()"
+      >
+        Escena 3D
+      </button>
+      <button
+        type="button"
+        [class.active]="viewMode === 'camera'"
+        [disabled]="cameraStarting || !cameraSupported"
+        (click)="startCamera()"
+      >
+        {{ cameraStarting ? 'Abriendo…' : 'Cámara' }}
+      </button>
+
+      @if (cameraActive && cameraDevices.length > 1) {
+        <select
+          class="camera-select"
+          aria-label="Seleccionar cámara"
+          [(ngModel)]="selectedCameraId"
+          (ngModelChange)="switchCamera($event)"
+        >
+          @for (device of cameraDevices; track device.deviceId) {
+            <option [value]="device.deviceId">{{ device.label }}</option>
+          }
+        </select>
+      }
+    </div>
+
     <div class="mode-toolbar" role="toolbar" aria-label="Modo de transformación">
       <button type="button" [class.active]="mode === 'translate'" (click)="setMode('translate')">
         Mover
@@ -13,8 +62,26 @@
       <button type="button" class="secondary" (click)="reset()">Reiniciar</button>
     </div>
 
+    @if (!cameraSupported) {
+      <div class="camera-message error" role="status">
+        Este navegador no permite acceder a la cámara.
+      </div>
+    } @else if (!secureContext) {
+      <div class="camera-message warning" role="status">
+        La cámara solo funciona desde HTTPS o localhost.
+      </div>
+    } @else if (cameraError) {
+      <div class="camera-message error" role="alert">{{ cameraError }}</div>
+    } @else if (cameraActive && cameraDetails) {
+      <div class="camera-message success" role="status">{{ cameraDetails }}</div>
+    }
+
     <div class="viewport-hint">
-      Arrastra el gizmo · rueda/pinza para zoom · arrastra el fondo para orbitar
+      @if (viewMode === 'camera') {
+        La caja está en coordenadas relativas a la cámara · arrastra el gizmo para encajarla
+      } @else {
+        Arrastra el gizmo · rueda/pinza para zoom · arrastra el fondo para orbitar
+      }
     </div>
   </div>
 
@@ -24,6 +91,16 @@
       <h2>Ajuste preciso</h2>
       <p>Las medidas están expresadas en metros y la posición corresponde al centro del volumen.</p>
     </header>
+
+    @if (viewMode === 'camera') {
+      <div class="reference-warning">
+        <strong>Vista previa de cámara</strong>
+        <span>
+          La geometría puede ajustarse visualmente, pero esta pose todavía no está anclada al espacio.
+          WebXR aportará el sistema de referencia persistente.
+        </span>
+      </div>
+    }
 
     <div class="field-grid">
       <label>

--- a/frontend/src/app/furniture-box-editor.component.ts
+++ b/frontend/src/app/furniture-box-editor.component.ts
@@ -16,9 +16,16 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { TransformControls } from 'three/addons/controls/TransformControls.js';
 
+import {
+  CameraAccessError,
+  CameraDevice,
+  CameraSession,
+  CameraStreamService
+} from './camera-stream.service';
 import { FurnitureEditorState } from './spatial.models';
 
 type TransformMode = 'translate' | 'rotate' | 'scale';
+type ViewMode = 'scene' | 'camera';
 
 type DisposableRenderable = THREE.Object3D & {
   geometry?: THREE.BufferGeometry;
@@ -37,9 +44,13 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   @ViewChild('viewport', { static: true })
   private readonly viewportRef!: ElementRef<HTMLDivElement>;
 
+  @ViewChild('cameraVideo', { static: true })
+  private readonly cameraVideoRef!: ElementRef<HTMLVideoElement>;
+
   @Output() readonly editorChange = new EventEmitter<FurnitureEditorState>();
 
   mode: TransformMode = 'translate';
+  viewMode: ViewMode = 'scene';
   positionX = 0;
   positionY = 1.1;
   positionZ = 0;
@@ -48,22 +59,50 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   height = 2.2;
   depth = 0.6;
 
+  readonly cameraSupported: boolean;
+  readonly secureContext: boolean;
+  cameraDevices: readonly CameraDevice[] = [];
+  selectedCameraId = '';
+  cameraError: string | null = null;
+  cameraDetails: string | null = null;
+  cameraActive = false;
+  cameraStarting = false;
+  mirrorVideo = false;
+
+  private readonly cameraStream = inject(CameraStreamService);
   private readonly changeDetector = inject(ChangeDetectorRef);
   private readonly ngZone = inject(NgZone);
+  private readonly handleDeviceChange = (): void => {
+    if (this.cameraActive) {
+      void this.refreshCameraDevices();
+    }
+  };
+
   private scene?: THREE.Scene;
   private camera?: THREE.PerspectiveCamera;
   private renderer?: THREE.WebGLRenderer;
   private orbitControls?: OrbitControls;
   private transformControls?: TransformControls;
   private furnitureMesh?: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
+  private environmentGroup?: THREE.Group;
   private resizeObserver?: ResizeObserver;
+  private cameraPoseInitialized = false;
+
+  constructor() {
+    this.cameraSupported = this.cameraStream.isSupported();
+    this.secureContext = this.cameraStream.isSecureContext();
+  }
 
   ngAfterViewInit(): void {
     this.ngZone.runOutsideAngular(() => this.initializeScene());
+    navigator.mediaDevices?.addEventListener?.('devicechange', this.handleDeviceChange);
     this.emitState();
   }
 
   ngOnDestroy(): void {
+    navigator.mediaDevices?.removeEventListener?.('devicechange', this.handleDeviceChange);
+    this.cameraStream.stop();
+    this.detachVideoStream();
     this.resizeObserver?.disconnect();
     this.renderer?.setAnimationLoop(null);
     this.orbitControls?.dispose();
@@ -87,6 +126,67 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   setMode(mode: TransformMode): void {
     this.mode = mode;
     this.transformControls?.setMode(mode);
+  }
+
+  async startCamera(deviceId?: string): Promise<void> {
+    if (this.cameraStarting || !this.cameraSupported) {
+      return;
+    }
+
+    if (!this.secureContext) {
+      this.cameraError =
+        'La cámara requiere HTTPS o localhost. Abre la aplicación desde un origen seguro.';
+      this.changeDetector.markForCheck();
+      return;
+    }
+
+    this.cameraStarting = true;
+    this.cameraError = null;
+    this.cameraDetails = null;
+    this.changeDetector.markForCheck();
+
+    try {
+      const session = await this.cameraStream.start(deviceId || this.selectedCameraId || undefined);
+      await this.attachVideoStream(session);
+      this.cameraActive = true;
+      this.selectedCameraId = session.deviceId ?? this.selectedCameraId;
+      this.mirrorVideo = session.facingMode === 'user';
+      this.cameraDetails = this.describeSession(session);
+      await this.refreshCameraDevices();
+      this.enterCameraView();
+    } catch (error: unknown) {
+      this.cameraStream.stop();
+      this.detachVideoStream();
+      this.cameraActive = false;
+      this.cameraError =
+        error instanceof CameraAccessError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'No se pudo iniciar la cámara.';
+      this.enterSceneView();
+    } finally {
+      this.cameraStarting = false;
+      this.changeDetector.markForCheck();
+    }
+  }
+
+  async switchCamera(deviceId: string): Promise<void> {
+    this.selectedCameraId = deviceId;
+    if (this.cameraActive) {
+      await this.startCamera(deviceId);
+    }
+  }
+
+  stopCamera(): void {
+    this.cameraStream.stop();
+    this.detachVideoStream();
+    this.cameraActive = false;
+    this.cameraStarting = false;
+    this.cameraDetails = null;
+    this.mirrorVideo = false;
+    this.enterSceneView();
+    this.changeDetector.markForCheck();
   }
 
   applyNumericState(): void {
@@ -115,12 +215,12 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     this.height = 2.2;
     this.depth = 0.6;
     this.positionX = 0;
-    this.positionY = this.height / 2;
-    this.positionZ = 0;
+    this.positionY = this.viewMode === 'camera' ? 0 : this.height / 2;
+    this.positionZ = this.viewMode === 'camera' ? -3 : 0;
     this.yawDegrees = 0;
     this.applyNumericState();
 
-    if (this.camera && this.orbitControls) {
+    if (this.camera && this.orbitControls && this.viewMode === 'scene') {
       this.camera.position.set(4, 3, 5);
       this.orbitControls.target.set(0, 1, 0);
       this.orbitControls.update();
@@ -137,7 +237,8 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     this.camera = new THREE.PerspectiveCamera(50, 1, 0.05, 100);
     this.camera.position.set(4, 3, 5);
 
-    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    this.renderer.setClearColor(0x07111e, 1);
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.renderer.shadowMap.enabled = true;
     this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
@@ -151,6 +252,7 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     keyLight.castShadow = true;
     this.scene.add(keyLight);
 
+    this.environmentGroup = new THREE.Group();
     const floor = new THREE.Mesh(
       new THREE.PlaneGeometry(12, 12),
       new THREE.MeshStandardMaterial({
@@ -161,11 +263,12 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     );
     floor.rotation.x = -Math.PI / 2;
     floor.receiveShadow = true;
-    this.scene.add(floor);
+    this.environmentGroup.add(floor);
 
     const grid = new THREE.GridHelper(12, 24, 0x34d6ff, 0x244158);
     grid.position.y = 0.002;
-    this.scene.add(grid);
+    this.environmentGroup.add(grid);
+    this.scene.add(this.environmentGroup);
 
     const geometry = new THREE.BoxGeometry(1, 1, 1);
     const material = new THREE.MeshStandardMaterial({
@@ -173,7 +276,8 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
       transparent: true,
       opacity: 0.28,
       roughness: 0.35,
-      metalness: 0.1
+      metalness: 0.1,
+      depthTest: true
     });
 
     this.furnitureMesh = new THREE.Mesh(geometry, material);
@@ -210,7 +314,8 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
 
     this.transformControls.addEventListener('dragging-changed', (event) => {
       if (this.orbitControls) {
-        this.orbitControls.enabled = !(event as unknown as { value: boolean }).value;
+        this.orbitControls.enabled =
+          this.viewMode === 'scene' && !(event as unknown as { value: boolean }).value;
       }
     });
     this.transformControls.addEventListener('objectChange', () => {
@@ -222,11 +327,103 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
     this.resize();
 
     this.renderer.setAnimationLoop(() => {
-      this.orbitControls?.update();
+      if (this.viewMode === 'scene') {
+        this.orbitControls?.update();
+      }
       if (this.scene && this.camera) {
         this.renderer?.render(this.scene, this.camera);
       }
     });
+  }
+
+  private enterCameraView(): void {
+    if (!this.scene || !this.camera || !this.renderer || !this.furnitureMesh) {
+      return;
+    }
+
+    this.viewMode = 'camera';
+    this.scene.background = null;
+    this.scene.fog = null;
+    this.environmentGroup?.visible && (this.environmentGroup.visible = false);
+    this.renderer.setClearColor(0x000000, 0);
+    this.camera.fov = 60;
+    this.camera.position.set(0, 0, 0);
+    this.camera.quaternion.identity();
+    this.camera.updateProjectionMatrix();
+    this.camera.updateMatrixWorld(true);
+
+    if (this.orbitControls) {
+      this.orbitControls.enabled = false;
+      this.orbitControls.target.set(0, 0, -3);
+    }
+
+    if (!this.cameraPoseInitialized) {
+      this.furnitureMesh.position.set(0, 0, -3);
+      this.furnitureMesh.quaternion.identity();
+      this.cameraPoseInitialized = true;
+      this.syncFromMesh();
+    } else {
+      this.emitState();
+    }
+  }
+
+  private enterSceneView(): void {
+    if (!this.scene || !this.camera || !this.renderer) {
+      return;
+    }
+
+    this.viewMode = 'scene';
+    this.scene.background = new THREE.Color(0x07111e);
+    this.scene.fog = new THREE.Fog(0x07111e, 10, 24);
+    if (this.environmentGroup) {
+      this.environmentGroup.visible = true;
+    }
+    this.renderer.setClearColor(0x07111e, 1);
+    this.camera.fov = 50;
+    this.camera.position.set(4, 3, 5);
+    this.camera.updateProjectionMatrix();
+
+    if (this.orbitControls) {
+      this.orbitControls.enabled = true;
+      if (this.furnitureMesh) {
+        this.orbitControls.target.copy(this.furnitureMesh.position);
+      }
+      this.orbitControls.update();
+    }
+    this.emitState();
+  }
+
+  private async attachVideoStream(session: CameraSession): Promise<void> {
+    const video = this.cameraVideoRef.nativeElement;
+    video.muted = true;
+    video.playsInline = true;
+    video.srcObject = session.stream;
+    await video.play();
+  }
+
+  private detachVideoStream(): void {
+    const video = this.cameraVideoRef.nativeElement;
+    video.pause();
+    video.srcObject = null;
+  }
+
+  private async refreshCameraDevices(): Promise<void> {
+    try {
+      this.cameraDevices = await this.cameraStream.listVideoInputs();
+      if (!this.selectedCameraId && this.cameraDevices.length > 0) {
+        this.selectedCameraId = this.cameraDevices[0].deviceId;
+      }
+    } catch {
+      this.cameraDevices = [];
+    }
+    this.changeDetector.markForCheck();
+  }
+
+  private describeSession(session: CameraSession): string {
+    const resolution =
+      session.width && session.height ? `${session.width} × ${session.height}` : 'resolución automática';
+    const facing = session.facingMode === 'environment' ? 'trasera' : session.facingMode === 'user' ? 'frontal' : null;
+    return facing ? `${resolution} · cámara ${facing}` : resolution;
   }
 
   private resize(): void {
@@ -285,7 +482,8 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
         height: this.clampDimension(Math.abs(this.furnitureMesh.scale.y)),
         depth: this.clampDimension(Math.abs(this.furnitureMesh.scale.z))
       },
-      yawDegrees: this.yawDegrees
+      yawDegrees: this.yawDegrees,
+      referenceFrame: this.viewMode === 'camera' ? 'CAMERA_PREVIEW' : 'SPACE'
     });
   }
 

--- a/frontend/src/app/furniture-box-editor.component.ts
+++ b/frontend/src/app/furniture-box-editor.component.ts
@@ -32,6 +32,11 @@ type DisposableRenderable = THREE.Object3D & {
   material?: THREE.Material | THREE.Material[];
 };
 
+interface PoseSnapshot {
+  position: THREE.Vector3;
+  quaternion: THREE.Quaternion;
+}
+
 @Component({
   selector: 'arh-furniture-box-editor',
   standalone: true,
@@ -86,7 +91,8 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   private furnitureMesh?: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
   private environmentGroup?: THREE.Group;
   private resizeObserver?: ResizeObserver;
-  private cameraPoseInitialized = false;
+  private spacePoseSnapshot?: PoseSnapshot;
+  private cameraPreviewPose?: PoseSnapshot;
 
   constructor() {
     this.cameraSupported = this.cameraStream.isSupported();
@@ -341,10 +347,17 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
+    const enteringFromScene = this.viewMode !== 'camera';
+    if (enteringFromScene) {
+      this.spacePoseSnapshot = this.snapshotFurniturePose();
+    }
+
     this.viewMode = 'camera';
     this.scene.background = null;
     this.scene.fog = null;
-    this.environmentGroup?.visible && (this.environmentGroup.visible = false);
+    if (this.environmentGroup) {
+      this.environmentGroup.visible = false;
+    }
     this.renderer.setClearColor(0x000000, 0);
     this.camera.fov = 60;
     this.camera.position.set(0, 0, 0);
@@ -357,10 +370,13 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
       this.orbitControls.target.set(0, 0, -3);
     }
 
-    if (!this.cameraPoseInitialized) {
-      this.furnitureMesh.position.set(0, 0, -3);
-      this.furnitureMesh.quaternion.identity();
-      this.cameraPoseInitialized = true;
+    if (enteringFromScene) {
+      if (this.cameraPreviewPose) {
+        this.restoreFurniturePose(this.cameraPreviewPose);
+      } else {
+        this.furnitureMesh.position.set(0, 0, -3);
+        this.furnitureMesh.quaternion.identity();
+      }
       this.syncFromMesh();
     } else {
       this.emitState();
@@ -370,6 +386,14 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   private enterSceneView(): void {
     if (!this.scene || !this.camera || !this.renderer) {
       return;
+    }
+
+    const leavingCamera = this.viewMode === 'camera';
+    if (leavingCamera && this.furnitureMesh) {
+      this.cameraPreviewPose = this.snapshotFurniturePose();
+      if (this.spacePoseSnapshot) {
+        this.restoreFurniturePose(this.spacePoseSnapshot);
+      }
     }
 
     this.viewMode = 'scene';
@@ -390,7 +414,34 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
       }
       this.orbitControls.update();
     }
-    this.emitState();
+
+    if (leavingCamera) {
+      this.syncFromMesh();
+    } else {
+      this.emitState();
+    }
+  }
+
+  private snapshotFurniturePose(): PoseSnapshot {
+    if (!this.furnitureMesh) {
+      return {
+        position: new THREE.Vector3(),
+        quaternion: new THREE.Quaternion()
+      };
+    }
+
+    return {
+      position: this.furnitureMesh.position.clone(),
+      quaternion: this.furnitureMesh.quaternion.clone()
+    };
+  }
+
+  private restoreFurniturePose(snapshot: PoseSnapshot): void {
+    if (!this.furnitureMesh) {
+      return;
+    }
+    this.furnitureMesh.position.copy(snapshot.position);
+    this.furnitureMesh.quaternion.copy(snapshot.quaternion);
   }
 
   private async attachVideoStream(session: CameraSession): Promise<void> {
@@ -421,8 +472,15 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
 
   private describeSession(session: CameraSession): string {
     const resolution =
-      session.width && session.height ? `${session.width} × ${session.height}` : 'resolución automática';
-    const facing = session.facingMode === 'environment' ? 'trasera' : session.facingMode === 'user' ? 'frontal' : null;
+      session.width && session.height
+        ? `${session.width} × ${session.height}`
+        : 'resolución automática';
+    const facing =
+      session.facingMode === 'environment'
+        ? 'trasera'
+        : session.facingMode === 'user'
+          ? 'frontal'
+          : null;
     return facing ? `${resolution} · cámara ${facing}` : resolution;
   }
 
@@ -488,7 +546,9 @@ export class FurnitureBoxEditorComponent implements AfterViewInit, OnDestroy {
   }
 
   private clampDimension(value: number): number {
-    return this.round(Math.min(Math.max(Number.isFinite(value) ? Math.abs(value) : 0.1, 0.1), 20));
+    return this.round(
+      Math.min(Math.max(Number.isFinite(value) ? Math.abs(value) : 0.1, 0.1), 20)
+    );
   }
 
   private finiteOrZero(value: number): number {

--- a/frontend/src/app/spatial.models.ts
+++ b/frontend/src/app/spatial.models.ts
@@ -65,10 +65,13 @@ export interface RegisterFurnitureRequest {
   visualDescriptor: string | null;
 }
 
+export type EditorReferenceFrame = 'SPACE' | 'CAMERA_PREVIEW';
+
 export interface FurnitureEditorState {
   spaceTransform: Transform3DDto;
   bounds: Bounds3DDto;
   yawDegrees: number;
+  referenceFrame: EditorReferenceFrame;
 }
 
 export const IDENTITY_TRANSFORM: Transform3DDto = {


### PR DESCRIPTION
## Objetivo

Añadir el tercer vertical slice de AR Home: abrir la cámara del dispositivo y superponer el editor Three.js sobre el vídeo real para ajustar visualmente la caja del mueble.

## Qué incorpora

- Servicio de cámara basado en `navigator.mediaDevices.getUserMedia`.
- Preferencia inicial por `facingMode: environment`.
- Resolución ideal 1920×1080 y hasta 60 fps cuando el dispositivo lo soporte.
- Enumeración y cambio dinámico entre cámaras después de conceder permisos.
- Vídeo `playsinline`, silenciado y a pantalla completa.
- Canvas WebGL transparente sobre la captura.
- Retícula, viñeta, estado de resolución y detección de cámara frontal/trasera.
- Espejado automático para cámara frontal.
- Mapeo de errores de permiso, dispositivo ausente, cámara ocupada y restricciones incompatibles.
- Parada explícita de todas las pistas al cerrar el modo cámara o destruir el componente.
- Sistema de referencia frontend `CAMERA_PREVIEW` frente a `SPACE`.
- Bloqueo de persistencia para impedir que una pose relativa al visor se guarde como pose de habitación.
- Documentación de la necesidad de HTTPS o localhost.

## Decisión arquitectónica

`getUserMedia` aporta imagen, pero no tracking espacial. Por tanto, este PR permite ajustar geometría y posición visualmente, pero considera la pose como provisional. El registro en backend queda deshabilitado hasta volver a una referencia `SPACE` o hasta que el siguiente incremento WebXR produzca un anclaje válido.

## Validación

El workflow `Frontend CI` ejecutará el build Angular de producción con TypeScript estricto en Node.js 22.

## Siguiente incremento

Sesión WebXR `immersive-ar`, hit-test sobre superficies y transformación de la caja desde viewer space a un anclaje persistente del espacio.