### PR TITLE
docs: ratify spatial product constitution and MVP viability gate

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,107 @@
+# AR Home Constitution
+
+## Mission
+AR Home exists to make physical storage searchable and navigable. A successful system lets a user register an object in an indoor environment, leave or restart the application, return from a different position, recover a trustworthy device pose, and be guided to the correct storage location.
+
+The product is not a 3D-scanning demo. Geometry, reconstruction, AR overlays and AI are means to recover physical objects reliably.
+
+## 1. Spec before code
+Every feature starts from an approved specification that states user value, scope, non-goals, acceptance criteria and measurable outcomes. Implementation must not begin while material ambiguities remain.
+
+## 2. Atomic delivery
+Each task and pull request represents one independently reviewable concern. The default target is at most 300 net changed lines; larger changes require explicit justification. Infrastructure, domain, mobile/XR, spatial processing and UI changes are not mixed unless the contract itself is the concern under review.
+
+## 3. Contract-first boundaries
+Public APIs, events and spatial payloads are versioned before implementation. Breaking changes require a migration path and an ADR. Coordinate frames, axis conventions, units, timestamps, identifiers, confidence and provenance are explicit.
+
+## 4. Spatial correctness over visual plausibility
+Measured, inferred and manually confirmed spatial data are distinct. Every pose-producing subsystem records source, confidence, timestamp and algorithm/provider version. A visually convincing overlay is not accepted if its coordinate semantics or uncertainty are undefined.
+
+## 5. Localization is a replaceable capability
+Business and inventory domains must not depend directly on ARCore, Cloud Anchors, markers, COLMAP, Wi-Fi RTT, UWB or any single localization implementation.
+
+Localization providers expose a common pose contract equivalent to:
+
+```text
+PoseEstimate
+- transform: 6DoF pose in an explicit coordinate frame
+- confidence
+- uncertainty/covariance when available
+- source/provider
+- timestamp
+- provider/algorithm version
+```
+
+The product may combine multiple providers, but downstream navigation consumes the normalized result.
+
+## 6. Capability-driven mobile behavior
+ARCore, depth sensing, Wi-Fi RTT, UWB and other hardware/platform capabilities are optional accelerators unless a product tier explicitly requires them. The Android client detects supported capabilities at runtime and degrades deliberately.
+
+Unsupported capabilities must produce an actionable fallback, not undefined behavior.
+
+## 7. Relocalization across sessions is the primary technical gate
+Relative motion tracking alone is insufficient. The system is considered spatially viable only when, after a mapped environment has been recorded, a new application/session start from a different position can recover a sufficiently accurate global pose and maintain useful tracking while the user moves toward a target.
+
+The MVP viability gate is defined in `docs/mvp-viability-gate.md`.
+
+## 8. Global navigation and final approach may use different precision regimes
+The system does not require centimetric precision over an entire dwelling if the product objective can be achieved through hierarchical refinement.
+
+A valid strategy is:
+
+```text
+coarse/global localization
+→ room/route navigation
+→ target furniture recognition/relocalization
+→ local furniture coordinate frame
+→ precise compartment guidance
+```
+
+Precision requirements are therefore specified per navigation stage and validated against user-visible outcomes.
+
+## 9. Storage hierarchy and navigation graph are separate models
+Containment answers "where is this object stored?". Navigation answers "how do I reach it?". They must not be represented by the same graph.
+
+The containment model supports arbitrary recursive depth. The navigation model independently represents traversable connections, approach poses and routing constraints.
+
+## 10. Buy/integrate before rebuilding spatial infrastructure
+The project must prefer proven, suitably licensed components for VIO, SfM, feature extraction, matching and reconstruction until evidence shows they cannot satisfy the product requirements.
+
+A proprietary SLAM/VIO implementation requires an ADR documenting the measured limitation of available alternatives, expected competitive advantage, maintenance cost and licensing implications.
+
+## 11. Human validation remains authoritative
+Automatic reconstruction, detection and recognition must support review and correction. User-confirmed spatial identities and placements are never silently replaced by lower-confidence inference.
+
+## 12. Privacy and security by design
+Indoor imagery, geometry, device trajectories, poses and inventory data are sensitive. Specifications and plans address minimization, consent, retention, deletion, encryption, authorization, logging redaction and offline behavior.
+
+Raw captures are private by default and must not be exposed through public object URLs or unauthenticated APIs.
+
+## 13. Modular monolith first; specialized workers where justified
+The Java backend starts as a modular monolith. Service extraction requires evidence of an operational, runtime or scaling need. Spatial AI/GPU processing may remain in separate Python/C++ workers because its dependency and execution profile is materially different.
+
+## 14. Observable, reproducible and reversible systems
+Long-running mapping/relocalization processing exposes status, failure reasons and correlation identifiers. Spatial algorithm outputs are reproducible from versioned inputs and model/provider versions where practical. Jobs are idempotent and safe to retry. Migrations and deployments have rollback strategies.
+
+## 15. MVP is judged by object retrieval
+The MVP is not accepted merely because it can capture a room, render a mesh, show camera overlays or persist inventory.
+
+The minimum product story is:
+
+```text
+MAP → REGISTER → CLOSE/RESTART → RETURN → RELOCALIZE → NAVIGATE → FIND
+```
+
+A demo must prove that flow end to end in a mapped indoor environment using a supported Android device.
+
+## 16. Definition of done
+A task is done only when applicable code, tests, contracts, migrations, documentation, privacy/security analysis and operational diagnostics are complete; CI is green; and implementation matches the constitution, specification, plan and tasks.
+
+Spatial behavior additionally requires device/fixture evidence and stated tolerances.
+
+## Governance
+- This constitution overrides feature-level convenience.
+- Amendments require a dedicated governance PR and rationale.
+- Cross-module architectural decisions require an ADR under `docs/adr/`.
+- Product features follow: `constitution → specify → clarify → plan → tasks → analyze → implement → converge`.
+- Remaining uncertainty is represented as an explicit experiment or task; it is not hidden behind optimistic assumptions.

--- a/docs/mvp-viability-gate.md
+++ b/docs/mvp-viability-gate.md
@@ -1,0 +1,210 @@
+# MVP Spatial Retrieval Viability Gate
+
+## Purpose
+
+This document defines the technical go/no-go experiment that must succeed before AR Home invests significantly in inventory UX, automatic recognition, Home Assistant integration or production scaling.
+
+The question is intentionally narrow:
+
+> After mapping a small indoor environment, can a fresh Android session started from a different position recover a useful global 6DoF pose and maintain enough spatial consistency to guide a user to a previously registered storage target?
+
+If the answer is no, work remains focused on localization. If the answer is yes, the product can progress to the end-to-end MVP.
+
+## Demo environment
+
+The first controlled environment must contain at least:
+
+- two distinct rooms connected by a doorway or corridor;
+- one target furniture instance in the destination room;
+- one nested storage path with at least three containment levels below the room;
+- ten registered inventory objects, with at least one designated demo target;
+- visually distinct and visually repetitive areas so relocalization failure modes are observable.
+
+Example target:
+
+```text
+Home
+└── Bedroom
+    └── Wardrobe
+        └── Right module
+            └── Drawer 2
+                └── Organizer
+                    └── Compartment A
+                        └── Passport
+```
+
+## Required end-to-end story
+
+The acceptance demo executes the following without editing persisted spatial data between steps:
+
+1. Map the demo environment.
+2. Register the target furniture/storage hierarchy.
+3. Register the target object and its placement.
+4. Close the application and terminate its spatial session.
+5. Move to a different starting position in the mapped environment.
+6. Start a fresh application/spatial session.
+7. Search for the target object.
+8. Relocalize the device in the persistent environment coordinate frame.
+9. Guide the user through the environment toward the destination room/furniture.
+10. Refine localization at the destination when required.
+11. Identify the correct final storage container and display the target object record.
+
+A demo that depends on preserving the original AR session does not pass.
+
+## Phase A — Device capability spike
+
+Before implementing persistent localization, the Android probe records actual capabilities of the selected test device rather than relying on model assumptions.
+
+Required observations:
+
+- Android/device identity and OS version;
+- rear camera configurations and usable frame rates;
+- camera intrinsics when available;
+- accelerometer availability and sampling;
+- gyroscope availability and sampling;
+- rotation-vector availability;
+- magnetometer availability;
+- ARCore availability and session creation result;
+- ARCore tracking state and tracking failure reason;
+- ARCore Depth AUTOMATIC support;
+- raw depth/confidence availability where exposed;
+- CPU camera-frame acquisition while spatial tracking is active;
+- Wi-Fi RTT feature support;
+- runtime thermal/performance observations during a representative walk.
+
+The result is stored as a machine-readable capability report plus a human-readable test summary.
+
+### Phase A pass condition
+
+At least one viable tracking/capture path exists that can provide synchronized camera observations and relative device motion suitable for the persistent-localization experiment.
+
+Failure does not terminate the project; it selects a lower-level CameraX/IMU path instead of ARCore for the next experiment.
+
+## Phase B — Persistent relocalization experiment
+
+### Mapping run
+
+A user walks the environment once or more while the system records versioned spatial observations such as:
+
+- selected RGB keyframes;
+- timestamp;
+- camera intrinsics;
+- relative/VIO pose when available;
+- tracking quality;
+- optional depth;
+- optional IMU metadata;
+- optional coarse radio observations used only as priors.
+
+The processing pipeline creates a persistent environment map/reference representation.
+
+### Localization runs
+
+Perform at least 20 fresh-session trials distributed across multiple starting positions and orientations. At least five trials must begin in each of two different rooms.
+
+Each trial:
+
+1. starts with no retained volatile AR session state;
+2. begins at a recorded ground-truth/reference test point or a manually measured tolerance zone;
+3. attempts global relocalization;
+4. records time to first accepted pose;
+5. walks a route to the target room/furniture;
+6. records tracking losses and recoveries;
+7. records final target/container result.
+
+## Provisional acceptance thresholds
+
+These thresholds are product-oriented starting values and must be revised from measured evidence, not intuition.
+
+### Initial relocalization
+
+- successful accepted global relocalization in at least 18 of 20 trials (90%);
+- median time to accepted localization <= 5 s;
+- p95 time to accepted localization <= 10 s for successful trials;
+- no accepted pose may confidently place the user in the wrong room.
+
+### Route-level guidance
+
+- the route remains usable after initial localization in at least 90% of successful trials;
+- temporary tracking loss must produce a visible degraded state rather than silently presenting a false precise overlay;
+- the system can request/recover through a fallback relocalization action when confidence becomes insufficient.
+
+### Final approach
+
+- the system identifies the correct destination furniture in at least 18 of 20 trials;
+- after local refinement, the system identifies the correct target compartment/storage instruction in at least 18 of 20 trials;
+- the final UI must distinguish spatially measured/inferred guidance from semantic instructions such as "open drawer 2".
+
+### Safety against false confidence
+
+A false high-confidence localization is considered more severe than a declared localization failure.
+
+Any trial in which the system reports a high-confidence pose in the wrong room is a release-blocking defect until its failure mode is understood and bounded.
+
+## Fallback requirement
+
+The MVP may use a deterministic recovery mechanism such as a visual marker, augmented image or user-confirmed landmark when automatic relocalization confidence is insufficient.
+
+The fallback is acceptable only if:
+
+- it is explicitly surfaced to the user;
+- after recovery, continuous relative tracking resumes without requiring markers throughout the route;
+- the normalized localization contract remains unchanged for navigation consumers.
+
+The existence of a fallback does not excuse poor automatic-localization metrics; automatic and fallback success rates are reported separately.
+
+## Non-goals for the viability gate
+
+The following are explicitly excluded from this experiment:
+
+- automatic recognition of arbitrary household objects;
+- automatic generation of the entire storage hierarchy;
+- photorealistic 3D reconstruction;
+- centimetric accuracy across the full dwelling;
+- multi-floor navigation;
+- iOS support;
+- UWB infrastructure;
+- mandatory Wi-Fi RTT infrastructure;
+- Home Assistant integration;
+- multi-tenant production scaling;
+- custom proprietary SLAM/VIO implementation.
+
+## Go / investigate / no-go decision
+
+### GO
+
+Proceed to the end-to-end inventory/navigation MVP when Phase B passes and failure cases are understood well enough to define supported operating conditions.
+
+### INVESTIGATE
+
+Do not expand product scope when metrics are close but below threshold. Create atomic experiments for the dominant failure mode, for example:
+
+- weak visual retrieval;
+- incorrect feature correspondences;
+- VIO drift after localization;
+- repetitive-texture ambiguity;
+- poor low-light behavior;
+- device thermal throttling;
+- target-furniture local refinement.
+
+### NO-GO for the current localization approach
+
+Replace or redesign the localization provider when repeated controlled experiments cannot approach the acceptance thresholds without requirements incompatible with the intended consumer experience.
+
+This is not automatically a no-go for AR Home as a product; it is a no-go for that provider/architecture.
+
+## Evidence required in the PR/experiment report
+
+Every viability run must preserve:
+
+- device capability report;
+- app/provider versions;
+- environment/map version;
+- test-point definitions;
+- per-trial results;
+- latency distribution;
+- success/failure classification;
+- tracking-loss counts;
+- confidence values;
+- representative failure logs;
+- privacy-safe screenshots/video where useful;
+- explicit conclusion: GO, INVESTIGATE or provider NO-GO.


### PR DESCRIPTION
## Objetivo

Ratificar la gobernanza de AR Home sobre la rama `develop` actual y fijar el criterio técnico que decidirá si la estrategia de localización indoor es viable antes de ampliar el producto.

Este PR sustituye conceptualmente al PR apilado #14 para la constitución: conserva sus principios útiles, pero los actualiza para el producto de recuperación/navegación de objetos definido actualmente.

## Qué cambia

- añade `.specify/memory/constitution.md` sobre la historia actual de `develop`;
- define la misión como recuperación física de objetos, no como demo de reconstrucción 3D;
- establece `LocalizationProvider/PoseEstimate` como frontera sustituible;
- obliga a comportamiento capability-driven en Android;
- separa árbol de almacenamiento y grafo de navegación;
- permite precisión jerárquica: navegación global + refinamiento local;
- exige integrar/comprar componentes espaciales antes de implementar SLAM/VIO propio sin evidencia;
- convierte la relocalización entre sesiones en gate técnico principal;
- define el flujo de éxito del MVP: `MAP → REGISTER → CLOSE/RESTART → RETURN → RELOCALIZE → NAVIGATE → FIND`;
- añade `docs/mvp-viability-gate.md` con protocolo y métricas de aceptación.

## Gate provisional

La primera validación controlada exige 20 sesiones nuevas desde varias posiciones y, entre otros criterios:

- >= 90% de relocalizaciones globales aceptadas;
- mediana <= 5 s y p95 <= 10 s para obtener pose aceptada;
- cero poses de alta confianza que sitúen al usuario en la habitación equivocada;
- >= 90% de llegada correcta al mueble y compartimento objetivo;
- degradación/fallback explícitos cuando cae la confianza.

Los umbrales son provisionales y deberán evolucionar con evidencia medida.

## Alcance

Sólo documentación/gobernanza. No modifica backend, frontend, base de datos ni captura móvil.

## Validación

- rama creada directamente desde `develop`;
- no se arrastra la base histórica del PR #14;
- los criterios distinguen relocalización automática y fallback;
- los fallos de alta confianza se consideran más graves que una negativa explícita a localizar;
- los no-go aplican al proveedor/arquitectura de localización, no automáticamente al producto completo.

## Siguiente unidad atómica

Crear `mobile-android` capability spike y generar un informe real del dispositivo de prueba antes de implementar persistent relocalization.
