### PR TITLE
feat(android): add passive device capability probe

### DIFF
--- a/.github/workflows/mobile-android-ci.yml
+++ b/.github/workflows/mobile-android-ci.yml
@@ -1,0 +1,30 @@
+name: Mobile Android CI
+
+on:
+  pull_request:
+    paths:
+      - 'mobile-android/**'
+      - '.github/workflows/mobile-android-ci.yml'
+  push:
+    paths:
+      - 'mobile-android/**'
+      - '.github/workflows/mobile-android-ci.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: android-actions/setup-android@v3
+      - name: Install Android SDK
+        run: sdkmanager 'platforms;android-36' 'build-tools;36.0.0'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '9.5.0'
+      - name: Build and lint capability probe
+        working-directory: mobile-android
+        run: gradle :app:assembleDebug :app:lintDebug --stacktrace

--- a/mobile-android/.gitignore
+++ b/mobile-android/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+**/build/
+local.properties
+.idea/
+*.iml

--- a/mobile-android/README.md
+++ b/mobile-android/README.md
@@ -1,0 +1,33 @@
+# Android device capability probe
+
+Diagnostic-only Android application for issue #19. It measures capabilities from the real device instead of inferring them from a commercial model name.
+
+## Passive probe
+
+The current slice reports:
+
+- device and Android build identity;
+- rear Camera2 devices, hardware level, focal lengths, exposed intrinsic calibration, AE FPS ranges and YUV output sizes;
+- accelerometer, gyroscope, rotation vector and magnetic-field sensor metadata;
+- Wi-Fi RTT feature flag;
+- ARCore runtime availability;
+- battery temperature and basic runtime/memory information.
+
+It deliberately does **not** open the camera or start an ARCore `Session`. Active AR tracking, depth and CPU-frame acquisition are a separate atomic slice.
+
+## Build
+
+Requirements: JDK 17, Android SDK 36 and Gradle 9.5.
+
+```bash
+cd mobile-android
+gradle :app:assembleDebug :app:lintDebug
+```
+
+The APK is produced at `app/build/outputs/apk/debug/app-debug.apk`.
+
+## Report
+
+Launching the app runs the passive probe and writes a versioned JSON document to the app-specific external files directory under `capability-reports/`. The absolute path is displayed on screen.
+
+A report is evidence only for the device/build on which it was captured. No capability may be promoted to a product requirement solely from this report.

--- a/mobile-android/app/build.gradle.kts
+++ b/mobile-android/app/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("com.android.application")
+}
+
+android {
+    namespace = "io.arhome.capabilities"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "io.arhome.capabilities"
+        minSdk = 26
+        targetSdk = 36
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation("com.google.ar:core:1.54.0")
+}

--- a/mobile-android/app/src/main/AndroidManifest.xml
+++ b/mobile-android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.ar" android:required="false" />
+    <uses-feature android:name="android.hardware.wifi.rtt" android:required="false" />
+
+    <application
+        android:allowBackup="false"
+        android:label="AR Home Capability Probe"
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+
+        <meta-data
+            android:name="com.google.ar.core"
+            android:value="optional" />
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/mobile-android/app/src/main/java/io/arhome/capabilities/CapabilityCollector.kt
+++ b/mobile-android/app/src/main/java/io/arhome/capabilities/CapabilityCollector.kt
@@ -1,0 +1,149 @@
+package io.arhome.capabilities
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.graphics.ImageFormat
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.os.BatteryManager
+import android.os.Build
+import com.google.ar.core.ArCoreApk
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Instant
+
+class CapabilityCollector(private val context: Context) {
+
+    fun collect(): JSONObject = JSONObject().apply {
+        put("schemaVersion", 1)
+        put("capturedAt", Instant.now().toString())
+        put("device", device())
+        put("cameras", cameras())
+        put("sensors", sensors())
+        put("wifiRtt", context.packageManager.hasSystemFeature(PackageManager.FEATURE_WIFI_RTT))
+        put("arCore", arCore())
+        put("runtime", runtime())
+    }
+
+    private fun device() = JSONObject().apply {
+        put("manufacturer", Build.MANUFACTURER)
+        put("brand", Build.BRAND)
+        put("model", Build.MODEL)
+        put("device", Build.DEVICE)
+        put("product", Build.PRODUCT)
+        put("hardware", Build.HARDWARE)
+        put("androidRelease", Build.VERSION.RELEASE)
+        put("sdkInt", Build.VERSION.SDK_INT)
+        put("securityPatch", Build.VERSION.SECURITY_PATCH)
+    }
+
+    private fun cameras(): JSONArray {
+        val manager = context.getSystemService(CameraManager::class.java)
+        return JSONArray().apply {
+            manager.cameraIdList.forEach { id ->
+                try {
+                    val c = manager.getCameraCharacteristics(id)
+                    val facing = c[CameraCharacteristics.LENS_FACING]
+                    if (facing == CameraCharacteristics.LENS_FACING_BACK) {
+                        put(JSONObject().apply {
+                            put("id", id)
+                            put("lensFacing", "BACK")
+                            put("hardwareLevel", hardwareLevel(c[CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL]))
+                            put("sensorOrientationDegrees", c[CameraCharacteristics.SENSOR_ORIENTATION])
+                            put("focalLengthsMm", floats(c[CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS]))
+                            put("physicalSizeMm", c[CameraCharacteristics.SENSOR_INFO_PHYSICAL_SIZE]?.let {
+                                JSONObject().put("width", it.width).put("height", it.height)
+                            } ?: JSONObject.NULL)
+                            put("intrinsicCalibration", if (Build.VERSION.SDK_INT >= 28) {
+                                floats(c[CameraCharacteristics.LENS_INTRINSIC_CALIBRATION])
+                            } else JSONObject.NULL)
+                            put("aeFpsRanges", JSONArray().apply {
+                                c[CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES]
+                                    ?.forEach { put(JSONObject().put("min", it.lower).put("max", it.upper)) }
+                            })
+                            put("yuv420Sizes", JSONArray().apply {
+                                c[CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP]
+                                    ?.getOutputSizes(ImageFormat.YUV_420_888)
+                                    ?.sortedByDescending { it.width.toLong() * it.height }
+                                    ?.forEach { put("${it.width}x${it.height}") }
+                            })
+                        })
+                    }
+                } catch (e: Exception) {
+                    put(JSONObject().put("id", id).put("error", "${e.javaClass.simpleName}: ${e.message}"))
+                }
+            }
+        }
+    }
+
+    private fun sensors(): JSONObject {
+        val manager = context.getSystemService(SensorManager::class.java)
+        return JSONObject().apply {
+            listOf(
+                "accelerometer" to Sensor.TYPE_ACCELEROMETER,
+                "gyroscope" to Sensor.TYPE_GYROSCOPE,
+                "rotationVector" to Sensor.TYPE_ROTATION_VECTOR,
+                "magneticField" to Sensor.TYPE_MAGNETIC_FIELD,
+            ).forEach { (name, type) ->
+                val sensor = manager.getDefaultSensor(type)
+                put(name, sensor?.let { sensorJson(it) } ?: JSONObject.NULL)
+            }
+        }
+    }
+
+    private fun sensorJson(sensor: Sensor) = JSONObject().apply {
+        put("name", sensor.name)
+        put("vendor", sensor.vendor)
+        put("version", sensor.version)
+        put("resolution", sensor.resolution)
+        put("maximumRange", sensor.maximumRange)
+        put("minDelayUs", sensor.minDelay)
+        put("powerMa", sensor.power)
+        put("reportingMode", sensor.reportingMode)
+        put("wakeUp", sensor.isWakeUpSensor)
+    }
+
+    private fun arCore() = JSONObject().apply {
+        try {
+            val availability = ArCoreApk.getInstance().checkAvailability(context)
+            put("availability", availability.name)
+            put("supported", availability.isSupported)
+            put("transient", availability.isTransient)
+        } catch (e: Exception) {
+            put("availability", "ERROR")
+            put("error", "${e.javaClass.simpleName}: ${e.message}")
+        }
+    }
+
+    private fun runtime() = JSONObject().apply {
+        val battery = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val temperatureTenths = battery?.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, Int.MIN_VALUE)
+        if (temperatureTenths != null && temperatureTenths != Int.MIN_VALUE) {
+            put("batteryTemperatureC", temperatureTenths / 10.0)
+        } else {
+            put("batteryTemperatureC", JSONObject.NULL)
+        }
+        val runtime = Runtime.getRuntime()
+        put("memoryMaxBytes", runtime.maxMemory())
+        put("memoryTotalBytes", runtime.totalMemory())
+        put("memoryFreeBytes", runtime.freeMemory())
+        put("availableProcessors", runtime.availableProcessors())
+    }
+
+    private fun floats(values: FloatArray?): Any =
+        values?.let { JSONArray().apply { it.forEach(::put) } } ?: JSONObject.NULL
+
+    private fun hardwareLevel(value: Int?): Any = when (value) {
+        CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY -> "LEGACY"
+        CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LIMITED -> "LIMITED"
+        CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_FULL -> "FULL"
+        CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_3 -> "LEVEL_3"
+        CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_EXTERNAL -> "EXTERNAL"
+        null -> JSONObject.NULL
+        else -> "UNKNOWN($value)"
+    }
+}

--- a/mobile-android/app/src/main/java/io/arhome/capabilities/MainActivity.kt
+++ b/mobile-android/app/src/main/java/io/arhome/capabilities/MainActivity.kt
@@ -1,0 +1,70 @@
+package io.arhome.capabilities
+
+import android.app.Activity
+import android.os.Bundle
+import android.text.method.ScrollingMovementMethod
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import java.io.File
+
+class MainActivity : Activity() {
+
+    private lateinit var output: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(32, 32, 32, 32)
+        }
+        val runButton = Button(this).apply {
+            text = "Run passive capability probe"
+            setOnClickListener { runProbe() }
+        }
+        output = TextView(this).apply {
+            textSize = 14f
+            movementMethod = ScrollingMovementMethod()
+        }
+        root.addView(runButton, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        root.addView(
+            output,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
+        )
+        setContentView(root)
+        runProbe()
+    }
+
+    private fun runProbe() {
+        val report = CapabilityCollector(this).collect()
+        val base = getExternalFilesDir(null) ?: filesDir
+        val directory = File(base, "capability-reports").apply { mkdirs() }
+        val file = File(directory, "capabilities-${System.currentTimeMillis()}.json")
+        file.writeText(report.toString(2))
+
+        val cameras = report.getJSONArray("cameras")
+        val sensors = report.getJSONObject("sensors")
+        val arCore = report.getJSONObject("arCore")
+
+        output.text = buildString {
+            appendLine("AR Home Android capability probe")
+            appendLine()
+            appendLine("Device: ${report.getJSONObject("device").optString("manufacturer")} ${report.getJSONObject("device").optString("model")}")
+            appendLine("Android: ${report.getJSONObject("device").optString("androidRelease")} / API ${report.getJSONObject("device").optInt("sdkInt")}")
+            appendLine("Rear cameras reported: ${cameras.length()}")
+            appendLine("Accelerometer: ${sensors.has("accelerometer") && !sensors.isNull("accelerometer")}")
+            appendLine("Gyroscope: ${sensors.has("gyroscope") && !sensors.isNull("gyroscope")}")
+            appendLine("Rotation vector: ${sensors.has("rotationVector") && !sensors.isNull("rotationVector")}")
+            appendLine("Magnetometer: ${sensors.has("magneticField") && !sensors.isNull("magneticField")}")
+            appendLine("Wi-Fi RTT: ${report.optBoolean("wifiRtt")}")
+            appendLine("ARCore availability: ${arCore.optString("availability")}")
+            appendLine()
+            appendLine("Machine-readable report:")
+            appendLine(file.absolutePath)
+            appendLine()
+            appendLine("This passive probe does not open the camera or start an ARCore Session.")
+        }
+    }
+}

--- a/mobile-android/build.gradle.kts
+++ b/mobile-android/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("com.android.application") version "9.3.0" apply false
+}

--- a/mobile-android/gradle.properties
+++ b/mobile-android/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true

--- a/mobile-android/settings.gradle.kts
+++ b/mobile-android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ar-home-capability-probe"
+include(":app")


### PR DESCRIPTION
## Issue

Part of #19. Depends on #18.

## Scope

First atomic slice of the Android capability spike. Adds a native diagnostic app that reports passive/runtime-discoverable device capabilities without opening the camera or starting an ARCore session.

Measured/exported as JSON:

- Android/device build identity;
- rear Camera2 devices, hardware level, focal lengths, exposed intrinsic calibration, AE FPS ranges and YUV sizes;
- accelerometer, gyroscope, rotation vector and magnetometer metadata;
- Wi-Fi RTT feature support;
- ARCore availability;
- battery temperature and basic runtime/memory information.

## Architecture

- Native Android, no Capacitor/WebXR.
- AGP 9.3.0 with built-in Kotlin.
- ARCore SDK 1.54.0, declared AR Optional.
- No Compose/AppCompat/SceneView dependency for the diagnostic UI.
- Report written to the app-specific external files directory; no storage permission required.

## Explicit non-goals

- camera opening;
- ARCore `Session` creation;
- tracking state/pose;
- Depth API;
- raw depth/confidence;
- CPU camera-frame acquisition;
- navigation or inventory.

Those active measurements form the next atomic slice of #19.

## Atomicity exception

Net change is 364 added lines, above the constitution's 300-line default target. The excess is accepted for this bootstrap because the independently usable slice requires the standalone Gradle module, manifest, passive collector, minimal diagnostic screen and the CI that verifies them together. Product behavior, active camera/AR tracking and backend changes remain excluded.

## Verification

`Mobile Android CI` builds and lints the standalone `mobile-android` project using JDK 17, Gradle 9.5.0 and Android SDK 36.
