### PR TITLE
feat(android): add active ARCore capability probe

### DIFF
--- a/mobile-android/app/src/main/java/io/arhome/capabilities/ActiveArCoreProbeView.kt
+++ b/mobile-android/app/src/main/java/io/arhome/capabilities/ActiveArCoreProbeView.kt
@@ -1,0 +1,179 @@
+package io.arhome.capabilities
+
+import android.content.Context
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import android.opengl.GLSurfaceView
+import android.os.SystemClock
+import com.google.ar.core.Config
+import com.google.ar.core.NotYetAvailableException
+import com.google.ar.core.Session
+import com.google.ar.core.TrackingState
+import com.google.ar.core.exceptions.CameraNotAvailableException
+import org.json.JSONArray
+import org.json.JSONObject
+import javax.microedition.khronos.egl.EGLConfig
+import javax.microedition.khronos.opengles.GL10
+
+class ActiveArCoreProbeView(
+    context: Context,
+    private val session: Session,
+    private val automaticDepthSupported: Boolean,
+    private val rawDepthSupported: Boolean,
+) : GLSurfaceView(context), GLSurfaceView.Renderer {
+
+    private val lock = Any()
+    private var textureId = 0
+    private var frameCount = 0L
+    private var trackingFrames = 0L
+    private var pausedFrames = 0L
+    private var firstFrameNanos = 0L
+    private var lastFrameNanos = 0L
+    private var maxFrameGapMs = 0.0
+    private var trackingFailureReason = "NONE"
+    private var translation = floatArrayOf()
+    private var rotation = floatArrayOf()
+    private var focalLength = floatArrayOf()
+    private var principalPoint = floatArrayOf()
+    private var imageDimensions = intArrayOf()
+    private var cpuImage: JSONObject? = null
+    private var rawDepthImage: JSONObject? = null
+    private var confidenceImage: JSONObject? = null
+    private var lastError: String? = null
+
+    init {
+        setEGLContextClientVersion(2)
+        setRenderer(this)
+        renderMode = RENDERMODE_CONTINUOUSLY
+    }
+
+    override fun onSurfaceCreated(gl: GL10?, config: EGLConfig?) {
+        val textures = IntArray(1)
+        GLES20.glGenTextures(1, textures, 0)
+        textureId = textures[0]
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+        session.setCameraTextureNames(intArrayOf(textureId))
+    }
+
+    override fun onSurfaceChanged(gl: GL10?, width: Int, height: Int) {
+        GLES20.glViewport(0, 0, width, height)
+        session.setDisplayGeometry(display?.rotation ?: 0, width, height)
+    }
+
+    override fun onDrawFrame(gl: GL10?) {
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT or GLES20.GL_DEPTH_BUFFER_BIT)
+        val now = SystemClock.elapsedRealtimeNanos()
+        val frame = try {
+            session.update()
+        } catch (e: CameraNotAvailableException) {
+            synchronized(lock) { lastError = "CameraNotAvailableException: ${e.message}" }
+            return
+        } catch (e: Exception) {
+            synchronized(lock) { lastError = "${e.javaClass.simpleName}: ${e.message}" }
+            return
+        }
+
+        val camera = frame.camera
+        synchronized(lock) {
+            frameCount++
+            if (firstFrameNanos == 0L) firstFrameNanos = now
+            if (lastFrameNanos != 0L) {
+                maxFrameGapMs = maxOf(maxFrameGapMs, (now - lastFrameNanos) / 1_000_000.0)
+            }
+            lastFrameNanos = now
+            trackingFailureReason = camera.trackingFailureReason.name
+            if (camera.trackingState == TrackingState.TRACKING) {
+                trackingFrames++
+                translation = camera.pose.translation
+                rotation = camera.pose.rotationQuaternion
+                val intrinsics = camera.imageIntrinsics
+                focalLength = intrinsics.focalLength
+                principalPoint = intrinsics.principalPoint
+                imageDimensions = intrinsics.imageDimensions
+            } else {
+                pausedFrames++
+            }
+        }
+
+        if (camera.trackingState == TrackingState.TRACKING) {
+            acquireCpuImage(frame)
+            if (automaticDepthSupported) acquireRawDepth(frame)
+        }
+    }
+
+    private fun acquireCpuImage(frame: com.google.ar.core.Frame) {
+        synchronized(lock) { if (cpuImage != null) return }
+        try {
+            frame.acquireCameraImage().use { image ->
+                synchronized(lock) {
+                    cpuImage = JSONObject()
+                        .put("width", image.width)
+                        .put("height", image.height)
+                        .put("format", image.format)
+                        .put("timestampNs", image.timestamp)
+                }
+            }
+        } catch (_: NotYetAvailableException) {
+        } catch (e: Exception) {
+            synchronized(lock) { lastError = "CPU image: ${e.javaClass.simpleName}: ${e.message}" }
+        }
+    }
+
+    private fun acquireRawDepth(frame: com.google.ar.core.Frame) {
+        val needDepth = synchronized(lock) { rawDepthImage == null || confidenceImage == null }
+        if (!needDepth) return
+        try {
+            if (synchronized(lock) { rawDepthImage == null }) {
+                frame.acquireRawDepthImage16Bits().use { image ->
+                    synchronized(lock) {
+                        rawDepthImage = JSONObject()
+                            .put("width", image.width)
+                            .put("height", image.height)
+                            .put("timestampNs", image.timestamp)
+                    }
+                }
+            }
+            if (synchronized(lock) { confidenceImage == null }) {
+                frame.acquireRawDepthConfidenceImage().use { image ->
+                    synchronized(lock) {
+                        confidenceImage = JSONObject()
+                            .put("width", image.width)
+                            .put("height", image.height)
+                            .put("timestampNs", image.timestamp)
+                    }
+                }
+            }
+        } catch (_: NotYetAvailableException) {
+        } catch (e: Exception) {
+            synchronized(lock) { lastError = "Raw depth: ${e.javaClass.simpleName}: ${e.message}" }
+        }
+    }
+
+    fun snapshot(): JSONObject = synchronized(lock) {
+        val durationSeconds = if (firstFrameNanos > 0L && lastFrameNanos > firstFrameNanos) {
+            (lastFrameNanos - firstFrameNanos) / 1_000_000_000.0
+        } else 0.0
+        JSONObject().apply {
+            put("automaticDepthSupported", automaticDepthSupported)
+            put("rawDepthModeSupported", rawDepthSupported)
+            put("frameCount", frameCount)
+            put("trackingFrames", trackingFrames)
+            put("pausedFrames", pausedFrames)
+            put("trackingFailureReason", trackingFailureReason)
+            put("durationSeconds", durationSeconds)
+            put("averageUpdateHz", if (durationSeconds > 0) (frameCount - 1) / durationSeconds else 0.0)
+            put("maxFrameGapMs", maxFrameGapMs)
+            put("poseTranslationMeters", JSONArray(translation.toList()))
+            put("poseRotationQuaternion", JSONArray(rotation.toList()))
+            put("imageFocalLengthPixels", JSONArray(focalLength.toList()))
+            put("imagePrincipalPointPixels", JSONArray(principalPoint.toList()))
+            put("imageDimensionsPixels", JSONArray(imageDimensions.toList()))
+            put("cpuCameraImage", cpuImage ?: JSONObject.NULL)
+            put("rawDepthImage", rawDepthImage ?: JSONObject.NULL)
+            put("rawDepthConfidenceImage", confidenceImage ?: JSONObject.NULL)
+            put("lastError", lastError ?: JSONObject.NULL)
+        }
+    }
+}

--- a/mobile-android/app/src/main/java/io/arhome/capabilities/ActiveArCoreProbeView.kt
+++ b/mobile-android/app/src/main/java/io/arhome/capabilities/ActiveArCoreProbeView.kt
@@ -6,10 +6,10 @@ import android.opengl.GLES20
 import android.opengl.GLSurfaceView
 import android.os.SystemClock
 import com.google.ar.core.Config
-import com.google.ar.core.NotYetAvailableException
 import com.google.ar.core.Session
 import com.google.ar.core.TrackingState
 import com.google.ar.core.exceptions.CameraNotAvailableException
+import com.google.ar.core.exceptions.NotYetAvailableException
 import org.json.JSONArray
 import org.json.JSONObject
 import javax.microedition.khronos.egl.EGLConfig

--- a/mobile-android/app/src/main/java/io/arhome/capabilities/MainActivity.kt
+++ b/mobile-android/app/src/main/java/io/arhome/capabilities/MainActivity.kt
@@ -1,70 +1,208 @@
 package io.arhome.capabilities
 
+import android.Manifest
 import android.app.Activity
+import android.content.pm.PackageManager
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.text.method.ScrollingMovementMethod
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.google.ar.core.ArCoreApk
+import com.google.ar.core.Config
+import com.google.ar.core.Session
 import java.io.File
 
 class MainActivity : Activity() {
 
+    private lateinit var root: LinearLayout
     private lateinit var output: TextView
+    private val handler = Handler(Looper.getMainLooper())
+    private var session: Session? = null
+    private var activeProbe: ActiveArCoreProbeView? = null
+
+    private val refresh = object : Runnable {
+        override fun run() {
+            activeProbe?.let { showActiveSummary(it.snapshot()) }
+            if (activeProbe != null) handler.postDelayed(this, 1_000)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val root = LinearLayout(this).apply {
+        root = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(32, 32, 32, 32)
         }
-        val runButton = Button(this).apply {
-            text = "Run passive capability probe"
-            setOnClickListener { runProbe() }
-        }
+        root.addView(button("Run passive capability probe") { runPassiveProbe() })
+        root.addView(button("Start active ARCore probe") { ensureCameraThenStart() })
+        root.addView(button("Save active report") { saveActiveReport() })
         output = TextView(this).apply {
             textSize = 14f
             movementMethod = ScrollingMovementMethod()
         }
-        root.addView(runButton, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-        root.addView(
-            output,
-            LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f),
-        )
+        root.addView(output, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
         setContentView(root)
-        runProbe()
+        runPassiveProbe()
     }
 
-    private fun runProbe() {
+    override fun onResume() {
+        super.onResume()
+        val currentSession = session ?: return
+        try {
+            currentSession.resume()
+            activeProbe?.onResume()
+            handler.post(refresh)
+        } catch (e: Exception) {
+            output.text = "ARCore resume failed: ${e.javaClass.simpleName}: ${e.message}"
+        }
+    }
+
+    override fun onPause() {
+        handler.removeCallbacks(refresh)
+        activeProbe?.onPause()
+        session?.pause()
+        super.onPause()
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacks(refresh)
+        session?.close()
+        session = null
+        super.onDestroy()
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, results: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, results)
+        if (requestCode == CAMERA_REQUEST && results.firstOrNull() == PackageManager.PERMISSION_GRANTED) {
+            startActiveProbe()
+        } else if (requestCode == CAMERA_REQUEST) {
+            output.text = "Camera permission denied; active ARCore probe cannot run."
+        }
+    }
+
+    private fun button(label: String, action: () -> Unit) = Button(this).apply {
+        text = label
+        setOnClickListener { action() }
+    }
+
+    private fun ensureCameraThenStart() {
+        if (checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(arrayOf(Manifest.permission.CAMERA), CAMERA_REQUEST)
+        } else {
+            startActiveProbe()
+        }
+    }
+
+    private fun startActiveProbe() {
+        if (session != null) {
+            output.text = "Active ARCore probe is already running."
+            return
+        }
+        try {
+            val availability = ArCoreApk.getInstance().checkAvailability(this)
+            if (availability.isTransient) {
+                output.text = "ARCore availability is still being resolved: ${availability.name}. Retry the active probe."
+                return
+            }
+            if (!availability.isSupported) {
+                output.text = "ARCore is not supported on this device: ${availability.name}."
+                return
+            }
+            if (availability != ArCoreApk.Availability.SUPPORTED_INSTALLED) {
+                val install = ArCoreApk.getInstance().requestInstall(this, true)
+                output.text = "ARCore install/update result: $install. Run the active probe again after returning."
+                return
+            }
+
+            val newSession = Session(this)
+            val automaticDepth = newSession.isDepthModeSupported(Config.DepthMode.AUTOMATIC)
+            val rawDepth = newSession.isDepthModeSupported(Config.DepthMode.RAW_DEPTH_ONLY)
+            val config = newSession.config
+            if (automaticDepth) config.depthMode = Config.DepthMode.AUTOMATIC
+            newSession.configure(config)
+
+            val probeView = ActiveArCoreProbeView(this, newSession, automaticDepth, rawDepth)
+            val heightPx = (220 * resources.displayMetrics.density).toInt()
+            root.addView(
+                probeView,
+                root.childCount - 1,
+                LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, heightPx),
+            )
+            session = newSession
+            activeProbe = probeView
+            newSession.resume()
+            probeView.onResume()
+            handler.post(refresh)
+        } catch (e: Exception) {
+            session?.close()
+            session = null
+            activeProbe = null
+            output.text = "Active ARCore probe failed: ${e.javaClass.simpleName}: ${e.message}"
+        }
+    }
+
+    private fun runPassiveProbe() {
         val report = CapabilityCollector(this).collect()
+        val file = writeReport("capabilities", report.toString(2))
+        output.text = buildString {
+            val device = report.getJSONObject("device")
+            val sensors = report.getJSONObject("sensors")
+            appendLine("AR Home Android capability probe")
+            appendLine("Device: ${device.optString("manufacturer")} ${device.optString("model")}")
+            appendLine("Android: ${device.optString("androidRelease")} / API ${device.optInt("sdkInt")}")
+            appendLine("Rear cameras: ${report.getJSONArray("cameras").length()}")
+            appendLine("Accelerometer: ${!sensors.isNull("accelerometer")}")
+            appendLine("Gyroscope: ${!sensors.isNull("gyroscope")}")
+            appendLine("Rotation vector: ${!sensors.isNull("rotationVector")}")
+            appendLine("Magnetometer: ${!sensors.isNull("magneticField")}")
+            appendLine("Wi-Fi RTT: ${report.optBoolean("wifiRtt")}")
+            appendLine("ARCore: ${report.getJSONObject("arCore").optString("availability")}")
+            appendLine("Report: ${file.absolutePath}")
+        }
+    }
+
+    private fun showActiveSummary(active: org.json.JSONObject) {
+        output.text = buildString {
+            appendLine("ACTIVE ARCORE PROBE")
+            appendLine("Frames: ${active.optLong("frameCount")}")
+            appendLine("Tracking: ${active.optLong("trackingFrames")} / paused: ${active.optLong("pausedFrames")}")
+            appendLine("Failure reason: ${active.optString("trackingFailureReason")}")
+            appendLine("Average update Hz: %.1f".format(active.optDouble("averageUpdateHz")))
+            appendLine("Max frame gap ms: %.1f".format(active.optDouble("maxFrameGapMs")))
+            appendLine("Depth AUTOMATIC: ${active.optBoolean("automaticDepthSupported")}")
+            appendLine("Raw depth mode: ${active.optBoolean("rawDepthModeSupported")}")
+            appendLine("CPU camera image acquired: ${!active.isNull("cpuCameraImage")}")
+            appendLine("Raw depth acquired: ${!active.isNull("rawDepthImage")}")
+            appendLine("Confidence image acquired: ${!active.isNull("rawDepthConfidenceImage")}")
+            appendLine("Last error: ${active.opt("lastError")}")
+            appendLine()
+            appendLine("Walk normally for a representative sample, then tap Save active report.")
+        }
+    }
+
+    private fun saveActiveReport() {
+        val active = activeProbe?.snapshot()
+        if (active == null) {
+            output.text = "Start the active ARCore probe before saving an active report."
+            return
+        }
+        val report = CapabilityCollector(this).collect().put("activeArCore", active)
+        val file = writeReport("active-arcore", report.toString(2))
+        showActiveSummary(active)
+        output.append("\nSaved: ${file.absolutePath}")
+    }
+
+    private fun writeReport(prefix: String, content: String): File {
         val base = getExternalFilesDir(null) ?: filesDir
         val directory = File(base, "capability-reports").apply { mkdirs() }
-        val file = File(directory, "capabilities-${System.currentTimeMillis()}.json")
-        file.writeText(report.toString(2))
+        return File(directory, "$prefix-${System.currentTimeMillis()}.json").also { it.writeText(content) }
+    }
 
-        val cameras = report.getJSONArray("cameras")
-        val sensors = report.getJSONObject("sensors")
-        val arCore = report.getJSONObject("arCore")
-
-        output.text = buildString {
-            appendLine("AR Home Android capability probe")
-            appendLine()
-            appendLine("Device: ${report.getJSONObject("device").optString("manufacturer")} ${report.getJSONObject("device").optString("model")}")
-            appendLine("Android: ${report.getJSONObject("device").optString("androidRelease")} / API ${report.getJSONObject("device").optInt("sdkInt")}")
-            appendLine("Rear cameras reported: ${cameras.length()}")
-            appendLine("Accelerometer: ${sensors.has("accelerometer") && !sensors.isNull("accelerometer")}")
-            appendLine("Gyroscope: ${sensors.has("gyroscope") && !sensors.isNull("gyroscope")}")
-            appendLine("Rotation vector: ${sensors.has("rotationVector") && !sensors.isNull("rotationVector")}")
-            appendLine("Magnetometer: ${sensors.has("magneticField") && !sensors.isNull("magneticField")}")
-            appendLine("Wi-Fi RTT: ${report.optBoolean("wifiRtt")}")
-            appendLine("ARCore availability: ${arCore.optString("availability")}")
-            appendLine()
-            appendLine("Machine-readable report:")
-            appendLine(file.absolutePath)
-            appendLine()
-            appendLine("This passive probe does not open the camera or start an ARCore Session.")
-        }
+    companion object {
+        private const val CAMERA_REQUEST = 41
     }
 }


### PR DESCRIPTION
## Issue

Second atomic slice of #19. Depends on #22 and #18.

## Scope

Adds the active runtime probe required to decide whether ARCore is a viable tracking/capture provider on the test device.

The app now:

- requests camera permission only when the active probe is started;
- treats ARCore as optional and reports unsupported/transient/install states;
- creates and configures a real ARCore `Session` on the UI thread;
- checks `DepthMode.AUTOMATIC` and `RAW_DEPTH_ONLY` support;
- drives `Session.update()` from a minimal OpenGL ES surface;
- records tracking state/failure reason and current 6DoF camera pose;
- records ARCore image intrinsics;
- proves CPU camera-image acquisition while tracking;
- attempts raw depth and confidence-image acquisition when Depth is supported;
- measures update frequency and maximum observed frame gap;
- saves the active observations together with a fresh passive capability report after a representative walk.

## Non-goals

- rendering camera imagery/product AR UI;
- persistent relocalization;
- navigation;
- backend upload;
- Cloud Anchors;
- custom VIO/SLAM.

## Atomicity exception

Net change is 317 lines (351 additions, 34 deletions), 17 over the constitution's default 300-line target. The change remains one concern across two files: Activity lifecycle/permission orchestration and the minimal GL-thread ARCore probe. Splitting either half would produce a slice that cannot execute or be verified independently on hardware.

## Verification

The existing `Mobile Android CI` must pass `assembleDebug` and `lintDebug`. Hardware acceptance still requires running the resulting APK on the target Android device; CI cannot prove sensor/ARCore capabilities.
