### PR TITLE
ci(android): publish capability probe APK

### DIFF
--- a/.github/workflows/mobile-android-ci.yml
+++ b/.github/workflows/mobile-android-ci.yml
@@ -28,3 +28,10 @@ jobs:
       - name: Build and lint capability probe
         working-directory: mobile-android
         run: gradle :app:assembleDebug :app:lintDebug --stacktrace
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: ar-home-capability-probe-debug
+          path: mobile-android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Issue

Final CI/hardware-handoff slice of #19. Depends on #23, #22 and #18.

## Scope

Publishes the debug APK produced by the already-verified Android capability-probe build as a GitHub Actions artifact.

- artifact name: `ar-home-capability-probe-debug`;
- source: `mobile-android/app/build/outputs/apk/debug/app-debug.apk`;
- missing APK fails the workflow;
- retention: 14 days.

## Non-goals

No Android source, manifest, dependency, capability logic or product behavior changes.

## Verification

The same workflow still runs `assembleDebug` and `lintDebug` before publishing the APK. Hardware validation remains the final acceptance evidence for #19.
